### PR TITLE
Fix event listener cleanup

### DIFF
--- a/electron-preload.js
+++ b/electron-preload.js
@@ -210,15 +210,17 @@ contextBridge.exposeInMainWorld('electron', {
   
   // Container cleanup event handlers
   onStopAllContainersBeforeQuit: (callback) => {
-    ipcRenderer.on('stop-all-containers-before-quit', (event) => callback());
+    const wrapperFn = (event) => callback();
+    ipcRenderer.on('stop-all-containers-before-quit', wrapperFn);
     return () => {
-      ipcRenderer.removeListener('stop-all-containers-before-quit', callback);
+      ipcRenderer.removeListener('stop-all-containers-before-quit', wrapperFn);
     };
   },
   onStopAllContainersBeforeReload: (callback) => {
-    ipcRenderer.on('stop-all-containers-before-reload', (event) => callback());
+    const wrapperFn = (event) => callback();
+    ipcRenderer.on('stop-all-containers-before-reload', wrapperFn);
     return () => {
-      ipcRenderer.removeListener('stop-all-containers-before-reload', callback);
+      ipcRenderer.removeListener('stop-all-containers-before-reload', wrapperFn);
     };
   }
 }); 


### PR DESCRIPTION
## Summary
- fix event listener cleanup functions so that they actually remove the wrapper callbacks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68403398a7e8832d864c9f466a8e8f58