### PR TITLE
Update button disabled logic

### DIFF
--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -394,7 +394,7 @@ const ConfigSection = ({
                     // Optionally, show a user-facing error or notification here
                   }
                 }}
-                disabled={isLocked || !config.enabled} // Basic disable logic, can be expanded
+                disabled={isLocked || !config.enabled || isLogsDisabled()} // Disable when logs are unavailable
                 title={section.components.customButton.label} // Use label for tooltip
               >
                 <span className="custom-button-label">{section.components.customButton.label}</span>


### PR DESCRIPTION
## Summary
- disable custom button when helper `isLogsDisabled()` reports the logs aren't available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68403558fae4832db820f140a69b26dc