### PR TITLE
Add utility helpers and unit tests

### DIFF
--- a/__tests__/mainUtils.test.js
+++ b/__tests__/mainUtils.test.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const fs = require('fs').promises;
+const os = require('os');
+const { resolveEnvVars, checkPathExists } = require('../src/mainUtils');
+
+describe('resolveEnvVars', () => {
+  test('replaces $HOME with user home directory', () => {
+    const input = '$HOME/some/path';
+    const expected = path.join(os.homedir(), 'some/path');
+    expect(resolveEnvVars(input)).toBe(expected);
+  });
+
+  test('replaces $GOPATH when set', () => {
+    process.env.GOPATH = '/tmp/go';
+    expect(resolveEnvVars('$GOPATH/bin')).toBe('/tmp/go/bin');
+  });
+});
+
+describe('checkPathExists', () => {
+  test('validates existing directory', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'testdir-'));
+    const result = await checkPathExists(dir, '.', 'directory');
+    expect(result).toBe('valid');
+  });
+
+  test('returns invalid for missing file', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'testdir-'));
+    const result = await checkPathExists(tmpRoot, 'missing.txt', 'file');
+    expect(result).toBe('invalid');
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-react'
+  ]
+};

--- a/main.js
+++ b/main.js
@@ -34,44 +34,8 @@ const CONFIG_SIDEBAR_ABOUT_PATH = path.join(__dirname, 'src', 'configurationSide
 // Path to the configuration file that includes display settings
 const CONFIG_SIDEBAR_SECTIONS_PATH = path.join(__dirname, 'src', 'configurationSidebarSections.json');
 
-// Helper function to resolve environment variables in a string
-const resolveEnvVars = (str) => {
-  if (!str) return '';
-  // Resolve $HOME and other common vars like $GOPATH if set
-  let resolvedStr = str.replace(/\$HOME/g, os.homedir());
-  if (process.env.GOPATH) {
-    resolvedStr = resolvedStr.replace(/\$GOPATH/g, process.env.GOPATH);
-  }
-  // Add more replacements if needed, e.g., process.env[varName]
-  return resolvedStr;
-};
-
-const checkPathExists = async (relativePath, pathType = 'directory') => {
-  const absolutePath = path.join(projectRoot, relativePath);
-  try {
-    const stats = await fs.stat(absolutePath); // Use fs.stat to get path details
-    if (pathType === 'directory' && stats.isDirectory()) {
-      console.log(`Path check (directory): ${absolutePath} - valid`);
-      return 'valid';
-    } else if (pathType === 'file' && stats.isFile()) {
-      console.log(`Path check (file): ${absolutePath} - valid`);
-      return 'valid';
-    } else if (!pathType && (stats.isFile() || stats.isDirectory())) {
-      console.log(`Path check (any): ${absolutePath} - valid`);
-      return 'valid';
-    } else {
-      console.log(`Path check (${pathType}): ${absolutePath} - invalid (wrong type)`);
-      return 'invalid';
-    }
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      console.log(`Path check (${pathType}): ${absolutePath} - invalid (does not exist)`);
-    } else {
-      console.error(`Path check (${pathType}): ${absolutePath} - error accessing path:`, error);
-    }
-    return 'invalid';
-  }
-};
+// Utility helpers
+const { resolveEnvVars, checkPathExists } = require('./src/mainUtils');
 
 // Helper function to get Git branch with caching
 const gitBranchCache = {};
@@ -366,7 +330,7 @@ async function verifyEnvironment() {
                 ? path.join(projectRoot, pathValue.slice(2))
                 : resolveEnvVars(pathValue);
               
-              const pathStatus = await checkPathExists(pathValue.slice(2), pathType);
+              const pathStatus = await checkPathExists(projectRoot, pathValue.slice(2), pathType);
               result = pathStatus;
               break;
               

--- a/src/mainUtils.js
+++ b/src/mainUtils.js
@@ -1,0 +1,39 @@
+const path = require('path');
+const os = require('os');
+const fs = require('fs').promises;
+
+/**
+ * Resolve common environment variable placeholders like $HOME and $GOPATH.
+ * @param {string} str Input string with variables.
+ * @returns {string} Resolved string.
+ */
+function resolveEnvVars(str) {
+  if (!str) return '';
+  let resolvedStr = str.replace(/\$HOME/g, os.homedir());
+  if (process.env.GOPATH) {
+    resolvedStr = resolvedStr.replace(/\$GOPATH/g, process.env.GOPATH);
+  }
+  return resolvedStr;
+}
+
+/**
+ * Check if a relative path exists within the given project root.
+ * @param {string} projectRoot Base directory to resolve from.
+ * @param {string} relativePath Relative path to check.
+ * @param {string} [pathType='directory'] Expected type: 'file', 'directory', or falsy for any.
+ * @returns {Promise<'valid'|'invalid'>} Validation result.
+ */
+async function checkPathExists(projectRoot, relativePath, pathType = 'directory') {
+  const absolutePath = path.join(projectRoot, relativePath);
+  try {
+    const stats = await fs.stat(absolutePath);
+    if (pathType === 'directory' && stats.isDirectory()) return 'valid';
+    if (pathType === 'file' && stats.isFile()) return 'valid';
+    if (!pathType && (stats.isFile() || stats.isDirectory())) return 'valid';
+    return 'invalid';
+  } catch (err) {
+    return 'invalid';
+  }
+}
+
+module.exports = { resolveEnvVars, checkPathExists };


### PR DESCRIPTION
## Summary
- extract `resolveEnvVars` and `checkPathExists` from `main.js`
- expose them in new `src/mainUtils.js`
- update `main.js` to use the new module
- add Babel configuration for Jest
- create unit tests for new utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b56f3da0832d9c67f105f7acd3a2