### PR TITLE
Add e2e test for process cleanup

### DIFF
--- a/__tests__/e2e/processCleanup.test.js
+++ b/__tests__/e2e/processCleanup.test.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const { spawn } = require('child_process');
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+describe('Process cleanup', () => {
+  const script = path.join(__dirname, '..', '..', 'test-utils', 'ptyApp.js');
+
+  test('process is killed when terminal tab is closed', async () => {
+    const proc = spawn(process.execPath, [script], { stdio: ['pipe', 'pipe', 'inherit', 'ipc'] });
+    let childPid;
+    proc.stdout.on('data', (data) => {
+      const match = data.toString().match(/CHILD_PID:(\d+)/);
+      if (match) {
+        childPid = parseInt(match[1], 10);
+      }
+    });
+
+    // Wait for the child PID to be printed
+    await new Promise((resolve) => {
+      const check = setInterval(() => {
+        if (childPid) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 50);
+    });
+
+    proc.send('closeTab');
+
+    await new Promise((resolve) => proc.once('message', resolve));
+    await wait(100);
+
+    expect(isProcessRunning(childPid)).toBe(false);
+    proc.kill();
+  });
+
+  test('process is killed when app is terminated', async () => {
+    const proc = spawn(process.execPath, [script], { stdio: ['pipe', 'pipe', 'inherit', 'ipc'] });
+    let childPid;
+    proc.stdout.on('data', (data) => {
+      const match = data.toString().match(/CHILD_PID:(\d+)/);
+      if (match) {
+        childPid = parseInt(match[1], 10);
+      }
+    });
+
+    await new Promise((resolve) => {
+      const check = setInterval(() => {
+        if (childPid) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 50);
+    });
+
+    proc.kill('SIGTERM');
+    await new Promise((resolve) => proc.once('exit', resolve));
+    await wait(100);
+
+    expect(isProcessRunning(childPid)).toBe(false);
+  });
+});

--- a/test-utils/ptyApp.js
+++ b/test-utils/ptyApp.js
@@ -1,0 +1,35 @@
+const pty = require('node-pty');
+
+// Spawn a long-running process using Node
+const shell = process.platform === 'win32' ? 'cmd.exe' : process.execPath;
+const args = process.platform === 'win32' ? ['/c', 'ping -t 127.0.0.1'] : ['-e', 'setInterval(() => {}, 1000);'];
+const child = pty.spawn(shell, args, { name: 'xterm-color', cols: 80, rows: 30 });
+
+console.log(`CHILD_PID:${child.pid}`);
+
+function cleanup() {
+  try {
+    child.kill();
+  } catch (e) {
+    // ignore
+  }
+}
+
+process.on('message', (msg) => {
+  if (msg === 'closeTab') {
+    cleanup();
+    if (process.send) process.send('terminated');
+  }
+});
+
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+
+process.on('exit', cleanup);


### PR DESCRIPTION
## Summary
- add process cleanup E2E test
- add helper script to spawn a pty child

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bd36f600832d969ef4d654b98b07