### PR TITLE
Add config export/import feature

### DIFF
--- a/__tests__/configIO.test.js
+++ b/__tests__/configIO.test.js
@@ -1,0 +1,46 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+
+const { exportConfigToFile, importConfigFromFile } = require('../configIO');
+
+describe('Config import/export', () => {
+  const tmpDir = os.tmpdir();
+  const testFile = path.join(tmpDir, 'config_test.json');
+  const roundTripFile = path.join(tmpDir, 'config_roundtrip.json');
+
+  afterEach(async () => {
+    await fs.unlink(testFile).catch(() => {});
+    await fs.unlink(roundTripFile).catch(() => {});
+  });
+
+  test('exportConfigToFile writes JSON to file', async () => {
+    const data = { configState: { a: 1 }, attachState: { b: 2 } };
+    const result = await exportConfigToFile(data, testFile);
+    expect(result.success).toBe(true);
+
+    const content = await fs.readFile(testFile, 'utf-8');
+    expect(JSON.parse(content)).toEqual(data);
+  });
+
+  test('importConfigFromFile reads JSON from file', async () => {
+    const data = { configState: { x: 1 }, attachState: { y: 2 } };
+    await fs.writeFile(testFile, JSON.stringify(data), 'utf-8');
+
+    const result = await importConfigFromFile(testFile);
+    expect(result.success).toBe(true);
+    expect(result.configState).toEqual(data.configState);
+    expect(result.attachState).toEqual(data.attachState);
+  });
+
+  test('export and import round trip', async () => {
+    const data = {
+      configState: { foo: 'bar' },
+      attachState: { baz: true },
+      globalDropdownValues: { project: 'demo' }
+    };
+    await exportConfigToFile(data, roundTripFile);
+    const result = await importConfigFromFile(roundTripFile);
+    expect(result).toMatchObject({ success: true, ...data });
+  });
+});

--- a/configIO.js
+++ b/configIO.js
@@ -1,0 +1,25 @@
+const fs = require('fs').promises;
+
+async function exportConfigToFile(data, filePath) {
+  try {
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+async function importConfigFromFile(filePath) {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(content);
+    return { success: true, ...parsed };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+module.exports = {
+  exportConfigToFile,
+  importConfigFromFile,
+};

--- a/electron-preload.js
+++ b/electron-preload.js
@@ -207,6 +207,9 @@ contextBridge.exposeInMainWorld('electron', {
   // Container management
   stopContainers: (containerNames) => ipcRenderer.invoke('stop-containers', containerNames),
   getContainerStatus: (containerName) => ipcRenderer.invoke('get-container-status', containerName),
+
+  exportConfig: (data) => ipcRenderer.invoke('export-config', data),
+  importConfig: () => ipcRenderer.invoke('import-config'),
   
   // Container cleanup event handlers
   onStopAllContainersBeforeQuit: (callback) => {

--- a/main.js
+++ b/main.js
@@ -1,10 +1,11 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const os = require('os');
 const { exec, execSync } = require('child_process'); // Added execSync
 const fs = require('fs').promises;
 const fsSync = require('fs');
 const pty = require('node-pty'); // Added node-pty
+const { exportConfigToFile, importConfigFromFile } = require('./configIO');
 
 // Import shared constants
 const { projectSelectorFallbacks } = require('./src/constants/selectors');
@@ -861,6 +862,41 @@ ipcMain.handle('git-list-local-branches', async (event, { projectPath }) => {
   });
 });
 
+
+ipcMain.handle('export-config', async (event, data) => {
+  try {
+    const { canceled, filePath } = await dialog.showSaveDialog({
+      title: 'Export Configuration',
+      defaultPath: 'config.json',
+      filters: [{ name: 'JSON', extensions: ['json'] }]
+    });
+    if (canceled || !filePath) {
+      return { success: false, canceled: true };
+    }
+    return await exportConfigToFile(data, filePath);
+  } catch (error) {
+    console.error('Error exporting config:', error);
+    return { success: false, error: error.message };
+  }
+});
+
+ipcMain.handle('import-config', async () => {
+  try {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      title: 'Import Configuration',
+      properties: ['openFile'],
+      filters: [{ name: 'JSON', extensions: ['json'] }]
+    });
+    if (canceled || filePaths.length === 0) {
+      return { success: false, canceled: true };
+    }
+    return await importConfigFromFile(filePaths[0]);
+  } catch (error) {
+    console.error('Error importing config:', error);
+    return { success: false, error: error.message };
+  }
+});
+
 ipcMain.on('pty-spawn', (event, { command, terminalId, cols, rows }) => {
   if (activeProcesses[terminalId]) {
     console.warn(`Terminal ${terminalId} already has an active process.`);
@@ -971,4 +1007,9 @@ app.on('will-quit', async (event) => {
   
   // Now really quit
   app.exit(0);
-}); 
+});
+
+module.exports = {
+  exportConfigToFile,
+  importConfigFromFile,
+};

--- a/src/components/AppControlSidebar.jsx
+++ b/src/components/AppControlSidebar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import '../styles/app-control-sidebar.css'; // Renamed CSS
 // Import XMarkIcon as CloseIcon for clarity, or use XMarkIcon directly if no conflict
-import { Bars3Icon, XMarkIcon, EyeIcon, EyeSlashIcon, InformationCircleIcon, XMarkIcon as CloseIcon, Cog6ToothIcon, ArrowPathIcon, ComputerDesktopIcon, TrashIcon } from '@heroicons/react/24/outline'; // Example icons
+import { Bars3Icon, XMarkIcon, EyeIcon, EyeSlashIcon, InformationCircleIcon, XMarkIcon as CloseIcon, Cog6ToothIcon, ArrowPathIcon, ComputerDesktopIcon, TrashIcon, ArrowDownTrayIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
 
 const AppControlSidebar = ({
   floatingTerminals,
@@ -20,7 +20,9 @@ const AppControlSidebar = ({
   onToggleNoRunMode,
   showAppNotification, // Though showAppNotification might not be directly used by buttons here, it was part of DebugPanel
   isMainTerminalWritable, // New prop
-  onToggleMainTerminalWritable // New prop
+  onToggleMainTerminalWritable, // New prop
+  onExportConfig,
+  onImportConfig
 }) => {
   const sidebarRef = useRef(null);
   const [isDebugSectionOpen, setIsDebugSectionOpen] = useState(false);
@@ -190,6 +192,14 @@ const AppControlSidebar = ({
               <path fillRule="evenodd" d="M2 5a1 1 0 00-1 1v8a1 1 0 001 1h16a1 1 0 001-1V6a1 1 0 00-1-1H2zm3.293 2.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414L11.414 12l3.293 3.293a1 1 0 01-1.414 1.414L10 13.414l-3.293 3.293a1 1 0 01-1.414-1.414L8.586 12 5.293 8.707a1 1 0 010-1.414z" clipRule="evenodd" />
             </svg>
             <span>{isMainTerminalWritable ? 'Terminals Writable' : 'Terminals Read-Only'}</span>
+          </button>
+          <button onClick={onExportConfig} title="Export Configuration">
+            <ArrowDownTrayIcon className="icon" />
+            <span>Export Config</span>
+          </button>
+          <button onClick={onImportConfig} title="Import Configuration">
+            <ArrowUpTrayIcon className="icon" />
+            <span>Import Config</span>
           </button>
         </div>
       )}

--- a/src/components/IsoConfiguration.jsx
+++ b/src/components/IsoConfiguration.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from 'react';
 import ConfigSection from './ConfigSection';
 import Notification from './Notification';
 import StoppingStatusScreen from './StoppingStatusScreen';
@@ -12,7 +12,7 @@ import { evaluateCondition, generateCommandList } from '../utils/evalUtils';
 const { sections: configSidebarSectionsActual } = configSidebarSections;
 
 // Props now include globalDropdownValues from App.jsx and terminalRef from TerminalManager.jsx
-const IsoConfiguration = ({ projectName, globalDropdownValues, terminalRef, verificationStatuses, onTriggerRefresh, showTestSections = false, onConfigStateChange, onIsRunningChange, openFloatingTerminal }) => {
+const IsoConfiguration = forwardRef(({ projectName, globalDropdownValues, terminalRef, verificationStatuses, onTriggerRefresh, showTestSections = false, onConfigStateChange, onIsRunningChange, openFloatingTerminal }, ref) => {
   // Initialize config state with default values
   const [configState, setConfigState] = useState({});
   // Track if an ISO is currently running
@@ -509,6 +509,14 @@ const IsoConfiguration = ({ projectName, globalDropdownValues, terminalRef, veri
       onConfigStateChange(configState);
     }
   }, [configState, onConfigStateChange, initialized]);
+
+  useImperativeHandle(ref, () => ({
+    getCurrentState: () => ({ configState, attachState }),
+    setStateFromImport: ({ configState: newConfig, attachState: newAttach }) => {
+      if (newConfig) setConfigState(newConfig);
+      if (newAttach) setAttachState(newAttach);
+    }
+  }));
 
   return (
     <div className="config-container">


### PR DESCRIPTION
## Summary
- add exportConfigToFile/importConfigFromFile helpers
- expose these helpers for tests and use them in IPC handlers
- create unit tests to verify config export/import logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845c1faf98c832da9f87ff66dc24364