### PR TITLE
Fix Node version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProjectName Manager
 
-> **Note:** This project requires Node.js version 22.16.0. It is recommended to use [nvm](https://github.com/nvm-sh/nvm) to manage your Node.js versions. Once you have `nvm` installed, you can run `nvm use` in the project directory to automatically switch to the correct Node.js version.
+> **Note:** The Electron app requires Node.js **22.16.0**. Terminal commands can run on Node.js **15** or **16**. It is recommended to use [nvm](https://github.com/nvm-sh/nvm) to manage multiple Node.js versions. Once you have `nvm` installed, you can run `nvm use` in the project directory to automatically switch to the correct version for the Electron runtime.
 
 # {ProjectName} Manager
 
@@ -51,9 +51,10 @@ This project is also an experiment in "vibe coding" mixed with solid code practi
 
 ## 🏃 Quick Start
 
-### Prerequisites
+-### Prerequisites
 
-- Node.js (v16 or higher)
+- Node.js 22.16.0 for the Electron app
+- Node.js 15 or 16 for command execution
 - npm or yarn
 - Git
 
@@ -218,7 +219,7 @@ Define commands for main sections and for `customButton` actions.
     },
     "command": {
       "base": "cd your-section && docker-compose up",
-      "prefix": "nvm use 15.5.1 && ",
+      "prefix": "nvm use 16 && ",
       "tabTitle": "Your Section (Container)"
     }
   },
@@ -230,7 +231,7 @@ Define commands for main sections and for `customButton` actions.
     },
     "command": {
       "base": "cd your-section && npm start",
-      "prefix": "nvm use 15.5.1 && ",
+      "prefix": "nvm use 16 && ",
       "tabTitle": "Your Section (Process)"
     }
   },
@@ -261,7 +262,7 @@ Define commands for main sections and for `customButton` actions.
       { "name": "conditional-container", "condition": "deploymentType === 'container'" }
     ],
     "postModifiers": " --verbose",
-    "prefix": "nvm use 15.5.1 && ",
+    "prefix": "nvm use 16 && ",
     "tabTitle": {
       "base": "Your Main Section",
       "conditionalAppends": [
@@ -343,10 +344,10 @@ Verifies command output contains specific text. Can also check for one of multip
 ```json
 {
   "id": "nodeVersionCheck",
-  "title": "Node.js 16+ or 18+",
+  "title": "Node.js 15.x or 16.x",
   "checkType": "outputContains",
   "command": "nvm ls",
-  "expectedValue": ["v16.", "v18."],
+  "expectedValue": ["v15.", "v16."],
   "versionId": "nodeVersion",
   "outputStream": "stderr"
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -504,7 +504,6 @@ graph TB
 - [Terminal Features](terminal-features.md) - Terminal system capabilities
 - [Command System](command-system.md) - Command generation and execution
 - [Verification Types](verification-types.md) - Environment verification reference
-- [API Reference](api-reference.md) - Internal API documentation
 
 ---
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -360,7 +360,7 @@ Commands should be defined using separate command objects for each variant. This
     },
     "command": {
       "base": "cd your-section && docker-compose up",
-      "prefix": "nvm use 15.5.1 && ",
+      "prefix": "nvm use 16 && ",
       "tabTitle": "Your Section (Container)"
     }
   },
@@ -372,7 +372,7 @@ Commands should be defined using separate command objects for each variant. This
     },
     "command": {
       "base": "cd your-section && npm start",
-      "prefix": "nvm use 15.5.1 && ",
+      "prefix": "nvm use 16 && ",
       "tabTitle": "Your Section (Process)"
     }
   }

--- a/docs/verification-types.md
+++ b/docs/verification-types.md
@@ -120,10 +120,10 @@ Verifies that command output contains specific text. This check is highly flexib
 ```json
 {
   "id": "nodeVersionCheck",
-  "title": "Node.js (16, 18, or 20)",
+  "title": "Node.js (15 or 16)",
   "checkType": "outputContains",
   "command": "nvm ls",
-  "expectedValue": ["v16.", "v18.", "v20."],
+  "expectedValue": ["v15.", "v16."],
   "versionId": "nodeVersion"
 }
 ```
@@ -456,10 +456,10 @@ When combined with the `versionId` property, the first value from the array that
 ```json
 {
   "id": "nodeVersionCheck",
-  "title": "Node.js (16, 18, or 20)",
+  "title": "Node.js (15 or 16)",
   "checkType": "outputContains",
   "command": "nvm ls",
-  "expectedValue": ["v16.", "v18.", "v20."],
+  "expectedValue": ["v15.", "v16."],
   "versionId": "nodeVersion",
   "outputStream": "stdout"
 }

--- a/src/generalEnvironmentVerifications.json
+++ b/src/generalEnvironmentVerifications.json
@@ -84,10 +84,10 @@
         "verifications": [
           {
             "id": "nodeJs",
-            "title": "Node.js 15.5.1 or newer",
+            "title": "Node.js 15.x or 16.x",
             "command": "nvm ls",
             "checkType": "outputContains",
-            "expectedValue": "15.5.1",
+            "expectedValue": ["v15.", "v16."],
             "versionId": "nodeVersion",
             "outputStream": "stdout"
           },


### PR DESCRIPTION
## Summary
- clarify Node versions required for Electron and command execution
- adjust Node environment checks for Node 15.x or 16.x
- use Node 16 in config examples
- remove missing API reference link
- revert test updates to keep Node 15 expectations

## Testing
- `npm test` *(fails: `source: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684af8da0d20832db1d29fc244f78f69