### PR TITLE
Enable sub-section custom buttons

### DIFF
--- a/__tests__/ConfigSection.test.jsx
+++ b/__tests__/ConfigSection.test.jsx
@@ -284,6 +284,59 @@ describe('ConfigSection', () => {
         );
     });
 
+    it('renders sub-section custom button and handles click', () => {
+        const mockSection = {
+            id: 'parent-section',
+            title: 'Parent Section',
+            components: {
+                toggle: true,
+                subSections: [
+                    {
+                        id: 'child-sub',
+                        title: 'Child Sub',
+                        components: {
+                            toggle: true,
+                            customButton: {
+                                id: 'childLogs',
+                                label: 'Sub Logs',
+                                commandId: 'childLogCommand'
+                            }
+                        }
+                    }
+                ]
+            }
+        };
+
+        const mockCommands = [{
+            sectionId: 'childLogCommand',
+            command: {
+                base: 'echo child log',
+                tabTitle: 'Child Logs'
+            }
+        }];
+
+        const config = { enabled: true, childConfig: { enabled: true } };
+
+        render(
+            <ConfigSection
+                {...baseProps}
+                section={mockSection}
+                config={config}
+                configSidebarCommands={mockCommands}
+            />
+        );
+
+        const button = screen.getByText('Sub Logs');
+        expect(button).toBeInTheDocument();
+        fireEvent.click(button);
+
+        expect(baseProps.openFloatingTerminal).toHaveBeenCalledWith(
+            'childLogCommand',
+            'Sub Logs',
+            'echo child log'
+        );
+    });
+
     it('handles TBD options in ModeSelector correctly', () => {
         const section = sectionsData.sections.find(s => s.id === 'test-section-generic');
         const config = { enabled: true, mode: 'alpha' };

--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -389,6 +389,55 @@ const ConfigSection = ({
                               })}
                           </div>
                         )}
+
+                        {subSection.components.customButtons && subSection.components.customButtons.length > 0 && (
+                          <div className="custom-buttons-container">
+                            {subSection.components.customButtons.map(button => {
+                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
+                              const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
+                              return (
+                                <button
+                                  key={button.id}
+                                  className="custom-button"
+                                  onClick={() => {
+                                    if (openFloatingTerminal) {
+                                      openFloatingTerminal(button.commandId, button.label, commandToRun);
+                                    }
+                                  }}
+                                  disabled={isDisabled}
+                                >
+                                  {button.label}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {subSection.components.customButton && !subSection.components.customButtons && (
+                          <div className="custom-buttons-container">
+                            {(() => {
+                              const button = subSection.components.customButton;
+                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
+                              const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
+                              return (
+                                <button
+                                  key={button.id}
+                                  className="custom-button"
+                                  onClick={() => {
+                                    if (openFloatingTerminal) {
+                                      openFloatingTerminal(button.commandId, button.label, commandToRun);
+                                    }
+                                  }}
+                                  disabled={isDisabled}
+                                >
+                                  {button.label}
+                                </button>
+                              );
+                            })()}
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- allow ConfigSection sub-sections to render custom buttons
- test new sub-section custom button behavior
- fix test config key for sub-section

## Testing
- `npm run test:jest` *(fails: `source: not found`)*
- `npm run build && npm run test:e2e` *(fails: `source: not found`)*
- `npx jest --config=jest.config.js`
- `npx jest --config=jest.config.mock.js`
- `npx playwright test --reporter=list` *(fails: electron unable to open X display)*

------
https://chatgpt.com/codex/tasks/task_e_684af961d310832da2d98e21418684f7