### PR TITLE
Add agent guidelines

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-engine-strict=true 
+engine-strict=true
+script-shell=/bin/bash

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,40 @@
+# Agent Guidelines
+
+This project contains **{ProjectName} Manager**, a cross-platform Electron application built with React. The docs directory provides detailed information on architecture, configuration, command generation and testing.
+
+## Environment configuration
+
+- Requires **Node.js 22.16.0**. Use `nvm use` in the project root to activate the correct version.
+- Install dependencies with `npm install` after cloning.
+- Rebuild native modules with `npm run rebuild` before starting the app.
+- Start the application using `npm start`.
+- For development mode run `npm run watch` in one terminal and `npm start` in another.
+- Ensure that npm runs scripts with Bash by adding `script-shell=/bin/bash` to `.npmrc`. This allows commands like `source ~/.nvm/nvm.sh` to work.
+
+### Setup script
+
+The repository includes a `setup.sh` script that installs [nvm](https://github.com/nvm-sh/nvm) and the required Node.js version if they are not already present. Codex automatically executes this script when initializing the container.
+
+For container customization, see [OpenAI docs](https://platform.openai.com/docs/codex/overview#environment-configuration).
+
+## Testing
+
+Testing practices follow `docs/testing-guide.md`:
+
+- Run all tests with `npm test`. Pretest and posttest scripts rebuild `node-pty` for the appropriate environment.
+- Jest tests only: `npm run test:jest` (use `:prod` or `:mock` for different data sets).
+- End-to-end tests: `HEADLESS=true npm run test:e2e` (or `npm run test:e2e:report`).
+- For tests that require the DOM, add `/** @jest-environment jsdom */` at the top of the file.
+- Mock configuration data lives under `__tests__/mock-data`.
+- If `node-pty` build errors occur, run `npm run rebuild`.
+
+## Additional documentation
+
+- `docs/architecture.md` – system design and data flow
+- `docs/configuration-guide.md` – JSON configuration files and concepts
+- `docs/command-system.md` – command generation mechanics
+- `docs/terminal-features.md` – terminal types and behaviour
+- `docs/verification-types.md` – reference for environment verification checks
+- `docs/llm-experiments.md` – background on AI tools used during development
+
+These resources provide the context needed when modifying or extending the project.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+# Install nvm if not present
+if [ ! -d "$HOME/.nvm" ]; then
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+fi
+source "$HOME/.nvm/nvm.sh"
+# Install and use the required Node.js version
+nvm install 22.16.0
+nvm use 22.16.0


### PR DESCRIPTION
## Summary
- document environment configuration and testing steps for AI agents
- add `script-shell=/bin/bash` to allow npm scripts to source `nvm`
- add `setup.sh` script that installs nvm and Node.js 22.16.0

## Testing
- `npm test` *(fails: playwright e2e tests cannot run in container)*

------
https://chatgpt.com/codex/tasks/task_e_684b02782688832da7a710ccca3fbd3b