### PR TITLE
Enable test sub-section button

### DIFF
--- a/__tests__/ConfigSection.test.jsx
+++ b/__tests__/ConfigSection.test.jsx
@@ -284,6 +284,59 @@ describe('ConfigSection', () => {
         );
     });
 
+    it('renders sub-section custom button and handles click', () => {
+        const mockSection = {
+            id: 'parent-section',
+            title: 'Parent Section',
+            components: {
+                toggle: true,
+                subSections: [
+                    {
+                        id: 'child-sub',
+                        title: 'Child Sub',
+                        components: {
+                            toggle: true,
+                            customButton: {
+                                id: 'childLogs',
+                                label: 'Sub Logs',
+                                commandId: 'childLogCommand'
+                            }
+                        }
+                    }
+                ]
+            }
+        };
+
+        const mockCommands = [{
+            sectionId: 'childLogCommand',
+            command: {
+                base: 'echo child log',
+                tabTitle: 'Child Logs'
+            }
+        }];
+
+        const config = { enabled: true, childConfig: { enabled: true } };
+
+        render(
+            <ConfigSection
+                {...baseProps}
+                section={mockSection}
+                config={config}
+                configSidebarCommands={mockCommands}
+            />
+        );
+
+        const button = screen.getByText('Sub Logs');
+        expect(button).toBeInTheDocument();
+        fireEvent.click(button);
+
+        expect(baseProps.openFloatingTerminal).toHaveBeenCalledWith(
+            'childLogCommand',
+            'Sub Logs',
+            'echo child log'
+        );
+    });
+
     it('handles TBD options in ModeSelector correctly', () => {
         const section = sectionsData.sections.find(s => s.id === 'test-section-generic');
         const config = { enabled: true, mode: 'alpha' };

--- a/__tests__/mock-data/mockConfigurationSidebarAbout.json
+++ b/__tests__/mock-data/mockConfigurationSidebarAbout.json
@@ -41,5 +41,10 @@
     "directoryPath": "test-section-generic",
     "description": "Description for generic test section.",
     "verifications": []
+  },
+  {
+    "sectionId": "testSubLogCommand",
+    "description": "About info for the test sub-section button command.",
+    "verifications": []
   }
-] 
+]

--- a/__tests__/mock-data/mockConfigurationSidebarCommands.json
+++ b/__tests__/mock-data/mockConfigurationSidebarCommands.json
@@ -50,5 +50,12 @@
       "base": "echo 'Running generic test section in alpha mode'",
       "tabTitle": "Generic Test (Alpha)"
     }
+  },
+  {
+    "sectionId": "testSubLogCommand",
+    "command": {
+      "base": "echo 'Sub section logs'",
+      "tabTitle": "Sub Logs"
+    }
   }
-] 
+]

--- a/__tests__/mock-data/mockConfigurationSidebarSections.json
+++ b/__tests__/mock-data/mockConfigurationSidebarSections.json
@@ -87,8 +87,23 @@
             { "value": "beta", "status": "TBD" }
           ],
           "default": "alpha"
-        }
+        },
+        "subSections": [
+          {
+            "id": "test-sub-section",
+            "title": "Test Sub Section",
+            "components": {
+              "toggle": true,
+              "customButton": {
+                "id": "testSubLogs",
+                "label": "Sub Logs",
+                "commandId": "testSubLogCommand"
+              }
+            }
+          }
+        ]
       }
     }
   ]
-} 
+}
+

--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -389,6 +389,55 @@ const ConfigSection = ({
                               })}
                           </div>
                         )}
+
+                        {subSection.components.customButtons && subSection.components.customButtons.length > 0 && (
+                          <div className="custom-buttons-container">
+                            {subSection.components.customButtons.map(button => {
+                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
+                              const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
+                              return (
+                                <button
+                                  key={button.id}
+                                  className="custom-button"
+                                  onClick={() => {
+                                    if (openFloatingTerminal) {
+                                      openFloatingTerminal(button.commandId, button.label, commandToRun);
+                                    }
+                                  }}
+                                  disabled={isDisabled}
+                                >
+                                  {button.label}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        )}
+
+                        {subSection.components.customButton && !subSection.components.customButtons && (
+                          <div className="custom-buttons-container">
+                            {(() => {
+                              const button = subSection.components.customButton;
+                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
+                              const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
+                              return (
+                                <button
+                                  key={button.id}
+                                  className="custom-button"
+                                  onClick={() => {
+                                    if (openFloatingTerminal) {
+                                      openFloatingTerminal(button.commandId, button.label, commandToRun);
+                                    }
+                                  }}
+                                  disabled={isDisabled}
+                                >
+                                  {button.label}
+                                </button>
+                              );
+                            })()}
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/configurationSidebarAbout.json
+++ b/src/configurationSidebarAbout.json
@@ -133,5 +133,10 @@
     "sectionId": "testAnalyticsLogCommand",
     "description": "Displays logs for the Test Analytics Engine in a floating terminal.",
     "verifications": []
+  },
+  {
+    "sectionId": "mlEngineLogCommand",
+    "description": "About info for the ML Engine logs button command.",
+    "verifications": []
   }
-] 
+]

--- a/src/configurationSidebarCommands.json
+++ b/src/configurationSidebarCommands.json
@@ -7,6 +7,13 @@
     }
   },
   {
+    "sectionId": "mlEngineLogCommand",
+    "command": {
+      "base": "echo 'ML Engine logs'",
+      "tabTitle": "ML Logs"
+    }
+  },
+  {
     "sectionId": "mirror",
     "conditions": {
       "enabled": true,

--- a/src/configurationSidebarSections.json
+++ b/src/configurationSidebarSections.json
@@ -191,6 +191,11 @@
               "modeSelector": {
                 "options": ["tensorflow", "pytorch", "sklearn"],
                 "labels": ["TensorFlow", "PyTorch", "Scikit-learn"]
+              },
+              "customButton": {
+                "id": "mlEngineLogs",
+                "label": "ML Logs",
+                "commandId": "mlEngineLogCommand"
               }
             }
           }


### PR DESCRIPTION
## Summary
- add ML Engine logs button to `test-analytics` sub-section
- define `mlEngineLogCommand` command and about info

## Testing
- `npm run test:jest` *(fails: `source: not found`)*
- `npm run build && npm run test:e2e` *(fails: `source: not found`)*
- `npx jest --config=jest.config.js`
- `npx jest --config=jest.config.mock.js`
- `npx playwright test --reporter=list` *(fails: unable to open X display)*

------
https://chatgpt.com/codex/tasks/task_e_684af961d310832da2d98e21418684f7