### PR TITLE
Fix env var replacement edge cases

### DIFF
--- a/__tests__/mainUtils.test.js
+++ b/__tests__/mainUtils.test.js
@@ -14,6 +14,16 @@ describe('resolveEnvVars', () => {
     process.env.GOPATH = '/tmp/go';
     expect(resolveEnvVars('$GOPATH/bin')).toBe('/tmp/go/bin');
   });
+
+  test('does not replace $GOPATH when used as part of a larger variable', () => {
+    process.env.GOPATH = '/tmp/go';
+    const input = '$GOPATH_EXTRA/bin';
+    expect(resolveEnvVars(input)).toBe('$GOPATH_EXTRA/bin');
+  });
+  test('does not replace $HOME when used as part of a larger variable', () => {
+    const input = '$HOME_DIR/some/path';
+    expect(resolveEnvVars(input)).toBe('$HOME_DIR/some/path');
+  });
 });
 
 describe('checkPathExists', () => {

--- a/src/mainUtils.js
+++ b/src/mainUtils.js
@@ -12,9 +12,11 @@ function resolveEnvVars(str) {
     return str; // Return the original value if it's not a string
   }
   if (!str) return '';
-  let resolvedStr = str.replace(/\$HOME/g, os.homedir());
+  // Only replace standalone $HOME and $GOPATH variables so similar names like
+  // $HOME_DIR are left intact
+  let resolvedStr = str.replace(/\$HOME(?![A-Za-z0-9_])/g, os.homedir());
   if (process.env.GOPATH) {
-    resolvedStr = resolvedStr.replace(/\$GOPATH/g, process.env.GOPATH);
+    resolvedStr = resolvedStr.replace(/\$GOPATH(?![A-Za-z0-9_])/g, process.env.GOPATH);
   }
   return resolvedStr;
 }


### PR DESCRIPTION
## Summary
- handle `$HOME_DIR` and `$GOPATH_EXTRA` properly in `resolveEnvVars`
- test new replacement behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f143e5f84832db0f108b8019c494c