### PR TITLE
Add new Jest tests for hooks and config utils

### DIFF
--- a/__tests__/configurationManagementUtils.test.js
+++ b/__tests__/configurationManagementUtils.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const {
+  validateConfiguration,
+  loadSectionConfiguration,
+  checkConfigurationFiles
+} = require('../src/main/configurationManagement');
+
+describe('configurationManagement utilities', () => {
+  test('validateConfiguration detects errors', () => {
+    const result = validateConfiguration({
+      sections: [{ title: 'No id' }],
+      displaySettings: 'bad'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test('validateConfiguration passes with minimal valid config', () => {
+    const result = validateConfiguration({
+      sections: [{ id: 'one', title: 'One' }],
+      displaySettings: {}
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  test('loadSectionConfiguration reads file', async () => {
+    const tmp = path.resolve('tmp-section-test.json');
+    await fs.writeFile(tmp, JSON.stringify({ a: 1 }), 'utf-8');
+    const res = await loadSectionConfiguration('tmp-section-test.json');
+    expect(res.success).toBe(true);
+    expect(res.config).toEqual({ a: 1 });
+    await fs.unlink(tmp);
+  });
+
+  test('loadSectionConfiguration handles missing file', async () => {
+    const res = await loadSectionConfiguration('/no/such/file.json');
+    expect(res.success).toBe(false);
+  });
+
+  test('checkConfigurationFiles reports existing paths', async () => {
+    const res = await checkConfigurationFiles();
+    expect(res.sidebarAbout.exists).toBe(true);
+    expect(res.sidebarSections.exists).toBe(true);
+  });
+});

--- a/__tests__/useProjectConfig.test.js
+++ b/__tests__/useProjectConfig.test.js
@@ -1,0 +1,63 @@
+jest.mock('../src/configurationSidebarSections.json', () => require('./mock-data/mockConfigurationSidebarSections.json'));
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useProjectConfig } from '../src/hooks/useProjectConfig';
+
+const noop = () => {};
+
+describe('useProjectConfig', () => {
+  test('initializes config and attach state', async () => {
+    const { result } = renderHook(() => useProjectConfig({}, false, noop));
+    await waitFor(() => expect(result.current.initialized).toBe(true));
+    expect(result.current.configState).toHaveProperty('generic-section-1');
+    expect(result.current.attachState).toHaveProperty('generic-section-1', false);
+  });
+
+  test('toggleSectionEnabled updates state with globals', async () => {
+    const globals = { 'mock-dropdown-1': 'option1' };
+    const { result } = renderHook(() => useProjectConfig(globals, false, noop));
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      result.current.toggleSectionEnabled('section-with-dropdowns', true);
+    });
+    const section = result.current.configState['section-with-dropdowns'];
+    expect(section.enabled).toBe(true);
+    expect(section['mock-dropdown-1']).toBe('option1');
+  });
+
+  test('setMode updates modes for sections and sub sections', async () => {
+    const { result } = renderHook(() => useProjectConfig({}, false, noop));
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      result.current.setMode('generic-section-1', 'run');
+      result.current.setMode('generic-section-1', 'dev', 'generic-subsection-1');
+    });
+    expect(result.current.configState['generic-section-1'].mode).toBe('run');
+    const sub = result.current.configState['generic-section-1']['generic-subsection-1Config'];
+    expect(sub.mode).toBe('dev');
+    expect(sub.deploymentType).toBe('dev');
+  });
+
+  test('setSectionDropdownValue marks dropdown as selected', async () => {
+    const { result } = renderHook(() => useProjectConfig({}, false, noop));
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      result.current.setSectionDropdownValue('section-with-dropdowns', 'mock-dropdown-1', 'choice');
+    });
+    const section = result.current.configState['section-with-dropdowns'];
+    expect(section['mock-dropdown-1']).toBe('choice');
+    expect(section['mock-dropdown-1Selected']).toBe(true);
+  });
+
+  test('updates when global dropdowns change', async () => {
+    const { result, rerender } = renderHook(({ global }) => useProjectConfig(global, false, noop), {
+      initialProps: { global: {} }
+    });
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      rerender({ global: { 'mock-dropdown-1': 'x' } });
+    });
+    await waitFor(() => result.current.configState['section-with-dropdowns']['mock-dropdown-1'] === 'x');
+    expect(result.current.configState['section-with-dropdowns']['mock-dropdown-1']).toBe('x');
+  });
+});


### PR DESCRIPTION
## Summary
- create tests for useProjectConfig hook
- add configuration management utility tests

## Testing
- `npm test`
- `npm run test:jest:coverage:text`

------
https://chatgpt.com/codex/tasks/task_e_684f72757dcc832d9544b594d685781f