### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/gitManagement.test.js
+++ b/__tests__/gitManagement.test.js
@@ -1,14 +1,24 @@
 const child_process = require('child_process');
+const fs = require('fs');
 
 jest.mock('child_process', () => ({
   exec: jest.fn()
 }));
 
 const git = require('../src/main/gitManagement');
-const { checkoutGitBranch, listLocalGitBranches } = git;
+const {
+  checkoutGitBranch,
+  listLocalGitBranches,
+  getGitBranch,
+  clearGitBranchCache,
+  getGitBranchCache,
+  refreshGitBranches
+} = git;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  fs.promises.readFile = jest.fn();
+  clearGitBranchCache();
 });
 
 describe('checkoutGitBranch', () => {
@@ -39,5 +49,46 @@ describe('listLocalGitBranches', () => {
     const result = await listLocalGitBranches('repo');
     expect(result.success).toBe(false);
     expect(result.branches).toEqual([]);
+  });
+});
+
+describe('getGitBranch and cache management', () => {
+  test('caches branch results', async () => {
+    child_process.exec.mockImplementation((cmd, opts, cb) => cb(null, 'main', ''));
+    const first = await getGitBranch('repo');
+    const second = await getGitBranch('repo');
+    expect(first).toBe('main');
+    expect(second).toBe('main');
+    expect(child_process.exec).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns cached unknown on error', async () => {
+    child_process.exec.mockImplementation((cmd, opts, cb) => cb(new Error('fail'), '', ''));
+    const res1 = await getGitBranch('repo');
+    expect(res1).toBe('unknown');
+    child_process.exec.mockImplementation((cmd, opts, cb) => cb(null, 'dev', ''));
+    const res2 = await getGitBranch('repo');
+    expect(res2).toBe('unknown'); // still cached
+  });
+
+  test('clearGitBranchCache removes cache', async () => {
+    child_process.exec.mockImplementation((cmd, opts, cb) => cb(null, 'main', ''));
+    await getGitBranch('repo');
+    clearGitBranchCache('repo');
+    await getGitBranch('repo');
+    expect(child_process.exec).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('refreshGitBranches', () => {
+  test('reads config and refreshes branches', async () => {
+    const config = JSON.stringify([
+      { sectionId: 'a', directoryPath: 'pathA' },
+      { sectionId: 'b' }
+    ]);
+    fs.promises.readFile.mockResolvedValue(config);
+    child_process.exec.mockImplementation((cmd, opts, cb) => cb(null, 'main', ''));
+    const result = await refreshGitBranches();
+    expect(result).toEqual({ a: { gitBranch: 'main' } });
   });
 });

--- a/__tests__/windowManagement.test.js
+++ b/__tests__/windowManagement.test.js
@@ -23,6 +23,8 @@ class MockBrowserWindow {
     this.maximize = jest.fn();
     this.unmaximize = jest.fn();
     this.hide = jest.fn();
+    this.setSize = jest.fn();
+    this.setPosition = jest.fn();
     this.getSize = jest.fn(() => [this.options.width, this.options.height]);
     this.getPosition = jest.fn(() => [0, 0]);
     this.isMaximized = jest.fn(() => false);
@@ -38,7 +40,20 @@ jest.mock('electron', () => ({
 }));
 
 const wm = require('../src/main/windowManagement');
-const { createWindow, openDevTools, reloadApp, minimizeMainWindow } = wm;
+const {
+  createWindow,
+  openDevTools,
+  reloadApp,
+  minimizeMainWindow,
+  maximizeMainWindow,
+  showMainWindow,
+  hideMainWindow,
+  getWindowState,
+  setWindowState,
+  sendToRenderer,
+  isWindowReady,
+  closeMainWindow
+} = wm;
 
 describe('windowManagement', () => {
   beforeEach(() => {
@@ -70,5 +85,78 @@ describe('windowManagement', () => {
     const result = minimizeMainWindow();
     expect(win.minimize).toHaveBeenCalled();
     expect(result.success).toBe(true);
+  });
+
+  test('maximizeMainWindow maximizes when not maximized', () => {
+    const win = createWindow();
+    win.isMaximized
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const result = maximizeMainWindow();
+    expect(win.maximize).toHaveBeenCalled();
+    expect(result).toEqual({ success: true, isMaximized: true });
+  });
+
+  test('maximizeMainWindow unmaximizes when already maximized', () => {
+    const win = createWindow();
+    win.isMaximized
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    const result = maximizeMainWindow();
+    expect(win.unmaximize).toHaveBeenCalled();
+    expect(result).toEqual({ success: true, isMaximized: false });
+  });
+
+  test('showMainWindow shows and focuses the window', () => {
+    const win = createWindow();
+    const res = showMainWindow();
+    expect(win.show).toHaveBeenCalled();
+    expect(win.focus).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  test('hideMainWindow hides the window', () => {
+    const win = createWindow();
+    const res = hideMainWindow();
+    expect(win.hide).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  test('getWindowState returns window info', () => {
+    const win = createWindow();
+    const state = getWindowState();
+    expect(state.success).toBe(true);
+    expect(state.state.width).toBe(win.options.width);
+    expect(state.state.height).toBe(win.options.height);
+  });
+
+  test('setWindowState applies state', () => {
+    const win = createWindow();
+    const res = setWindowState({ width: 800, height: 600, x: 10, y: 20, isMaximized: true });
+    expect(win.setSize).toHaveBeenCalledWith(800, 600);
+    expect(win.setPosition).toHaveBeenCalledWith(10, 20);
+    expect(win.maximize).toHaveBeenCalled();
+    expect(res.success).toBe(true);
+  });
+
+  test('sendToRenderer forwards messages', () => {
+    const win = createWindow();
+    const res = sendToRenderer('chan', { a: 1 });
+    expect(win.webContents.send).toHaveBeenCalledWith('chan', { a: 1 });
+    expect(res.success).toBe(true);
+  });
+
+  test('isWindowReady returns true when ready', () => {
+    const win = createWindow();
+    win.isDestroyed.mockReturnValue(false);
+    win.webContents.isLoading.mockReturnValue(false);
+    expect(isWindowReady()).toBe(true);
+  });
+
+  test('closeMainWindow calls close', () => {
+    const win = createWindow();
+    const res = closeMainWindow();
+    expect(win.close).toHaveBeenCalled();
+    expect(res.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- extend window management tests
- add git management cache and refresh tests

## Testing
- `npm run test:jest:coverage:text`

------
https://chatgpt.com/codex/tasks/task_e_684f75f1b0b0832d98045e9d7639d663