### PR TITLE
Update testing docs

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -6,7 +6,8 @@ This project contains **{ProjectName} Manager**, a cross-platform Electron appli
 
 - Requires **Node.js 22.16.0**. Use `nvm use` in the project root to activate the correct version.
 - Install dependencies with `npm install` after cloning.
-- Rebuild native modules with `npm run rebuild` before starting the app.
+- Native modules rebuild automatically when running `npm start`. If they fail,
+  run `npx @electron/rebuild -f -w node-pty`.
 - Start the application using `npm start`.
 - For development mode run `npm run watch` in one terminal and `npm start` in another.
 - Ensure that npm runs scripts with Bash by adding `script-shell=/bin/bash` to `.npmrc`. This allows commands like `source ~/.nvm/nvm.sh` to work.
@@ -26,7 +27,7 @@ Testing practices follow `docs/testing-guide.md`:
 - End-to-end tests: `HEADLESS=true npm run test:e2e` (or `npm run test:e2e:report`).
 - For tests that require the DOM, add `/** @jest-environment jsdom */` at the top of the file.
 - Mock configuration data lives under `__tests__/mock-data`.
-- If `node-pty` build errors occur, run `npm run rebuild`.
+- If `node-pty` build errors occur, run `npx @electron/rebuild -f -w node-pty`.
 
 ## Additional documentation
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -131,9 +131,12 @@ This ensures the Electron window is not shown during tests. You can also add `HE
 - `npm run test:jest:mock`: Runs Jest tests using mock configuration/data files for stable, generic test coverage.
 - `npm run test:e2e`: Builds the app and runs Playwright E2E tests (set `HEADLESS=true` for headless Electron window).
 - `npm run test:e2e:report`: Builds the app and runs Playwright E2E tests with the default Playwright reporter (for HTML or CI reports).
+- `npm run test:jest:coverage:text`: Generates a text coverage summary.
+- `npm run test:jest:coverage:html`: Generates an HTML coverage report.
+- `scripts/run-all-tests.sh`: Convenience script that runs Jest and Playwright tests.
 
 ## Troubleshooting
 
-- **`node-pty` compilation errors**: If you see errors related to `node-pty` or `NODE_MODULE_VERSION`, running `npm run rebuild` (for Electron) or `npm rebuild node-pty` (for Node) can often resolve the issue.
+- **`node-pty` compilation errors**: If you see errors related to `node-pty` or `NODE_MODULE_VERSION`, run `npx @electron/rebuild -f -w node-pty` or restart with `npm start` to rebuild automatically.
 - **`document is not defined`**: This error indicates that a test requiring a DOM is running in the `node` environment. Add `/** @jest-environment jsdom */` to the top of the test file.
 - **`toBeInTheDocument is not a function`**: This means the `@testing-library/jest-dom` matchers are not loaded. Ensure that `jest.setup.js` is correctly configured in `jest.config.js`. 


### PR DESCRIPTION
## Summary
- clarify rebuild steps in agent guide
- add coverage scripts and fix rebuild command in testing guide

## Testing
- `npm test`
- `HEADLESS=true npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_684f78ac48b4832db8b83112ccb8fa7e