### PR TITLE
Increase test coverage for hooks

### DIFF
--- a/__tests__/useTabManagement.test.js
+++ b/__tests__/useTabManagement.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useTabManagement } from '../src/hooks/useTabManagement';
+
+describe('useTabManagement hook', () => {
+  test('toggleOverflowTabs toggles state', () => {
+    const ref = { current: document.createElement('div') };
+    const { result } = renderHook(() => useTabManagement(ref, [], null));
+    act(() => { result.current.toggleOverflowTabs(); });
+    expect(result.current.overflowTabsOpen).toBe(true);
+  });
+
+  test('recalculateVisibleTabs moves overflowing tabs', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientWidth', { value: 90 });
+    const t1 = document.createElement('div');
+    t1.className = 'tab';
+    Object.defineProperty(t1, 'offsetWidth', { value: 50 });
+    const t2 = document.createElement('div');
+    t2.className = 'tab';
+    Object.defineProperty(t2, 'offsetWidth', { value: 50 });
+    container.appendChild(t1);
+    container.appendChild(t2);
+    document.body.appendChild(container);
+    const ref = { current: container };
+    const terms = [{ id: 1 }, { id: 2 }];
+    const { result } = renderHook(() => useTabManagement(ref, terms, 2));
+    act(() => { jest.runAllTimers(); });
+    expect(result.current.visibleTabs.map(t => t.id)).toEqual([2]);
+    expect(result.current.overflowTabs.map(t => t.id)).toEqual([1]);
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/useTerminals.test.js
+++ b/__tests__/useTerminals.test.js
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+jest.mock('../src/utils/evalUtils', () => ({
+  evaluateCommandCondition: jest.fn(() => true)
+}));
+import { useTerminals } from '../src/hooks/useTerminals';
+import { evaluateCommandCondition } from '../src/utils/evalUtils';
+
+describe('useTerminals hook', () => {
+  beforeEach(() => {
+    window.electron = {
+      killProcess: jest.fn(),
+      stopContainers: jest.fn().mockResolvedValue(),
+    };
+  });
+
+  afterEach(() => {
+    delete window.electron;
+    jest.restoreAllMocks();
+  });
+
+  test('openTabs creates terminals and sets active id', () => {
+    const { result } = renderHook(() => useTerminals({}, [], false));
+    const tabs = [
+      { command: 'echo 1', sectionId: 'one', title: 'One' },
+      { type: 'error', message: 'oops', sectionId: 'two' }
+    ];
+    act(() => result.current.openTabs(tabs));
+    expect(result.current.terminals).toHaveLength(2);
+    expect(result.current.terminals[0]).toMatchObject({ command: 'echo 1', status: 'pending_spawn' });
+    expect(result.current.terminals[1]).toHaveProperty('errorType', 'config');
+    expect(result.current.activeTerminalId).toBe(result.current.terminals[0].id);
+  });
+
+  test('handleRefreshTab builds command with refreshConfig', async () => {
+    evaluateCommandCondition.mockReturnValue(true);
+    const configSidebarCommands = [
+      {
+        command: {
+          refreshConfig: {
+            prependCommands: [{ command: 'pre-', condition: 'c' }],
+            appendCommands: [{ command: '-post', condition: 'c' }]
+          }
+        }
+      }
+    ];
+    const { result } = renderHook(() => useTerminals({}, configSidebarCommands, false));
+    act(() => {
+      result.current.openTabs([{ command: 'base', sectionId: 'one', commandDefinitionId: 0 }]);
+    });
+    const id = result.current.terminals[0].id;
+    await act(async () => {
+      await result.current.handleRefreshTab(id);
+    });
+    expect(window.electron.killProcess).toHaveBeenCalledWith(id);
+    expect(result.current.terminals[0].command).toBe('pre-base-post');
+    expect(result.current.terminals[0].refreshCount).toBe(1);
+  });
+
+  test('handleCloseTab removes terminal and updates active id', async () => {
+    const { result } = renderHook(() => useTerminals({}, [], false));
+    act(() => {
+      result.current.openTabs([
+        { command: 'a', sectionId: 'one' },
+        { command: 'b', sectionId: 'two' }
+      ]);
+    });
+    const first = result.current.terminals[0].id;
+    const second = result.current.terminals[1].id;
+    await act(async () => {
+      await result.current.handleCloseTab(first);
+    });
+    expect(window.electron.killProcess).toHaveBeenCalledWith(first);
+    expect(result.current.terminals).toHaveLength(1);
+    expect(result.current.activeTerminalId).toBe(second);
+  });
+
+  test('killAllTerminals aggregates containers and kills processes', async () => {
+    const { result } = renderHook(() => useTerminals({}, [], false));
+    act(() => {
+      result.current.openTabs([
+        { command: 'a', sectionId: 'one', associatedContainers: ['c1', 'c2'] },
+        { command: 'b', sectionId: 'two', associatedContainers: ['c2'] }
+      ]);
+    });
+    await act(async () => {
+      await result.current.killAllTerminals();
+    });
+    expect(window.electron.killProcess).toHaveBeenCalledTimes(2);
+    expect(window.electron.stopContainers).toHaveBeenCalledWith(['c1', 'c2']);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for useTerminals hook
- add tests for useTabManagement hook

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm run test:jest`
- `npx jest __tests__/useTerminals.test.js --coverage --coverageReporters=text`

------
https://chatgpt.com/codex/tasks/task_e_684f78084d94832da20820b5a1529b7b