### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/configIO.test.js
+++ b/__tests__/configIO.test.js
@@ -43,4 +43,18 @@ describe('Config import/export', () => {
     const result = await importConfigFromFile(roundTripFile);
     expect(result).toMatchObject({ success: true, ...data });
   });
+
+  test('exportConfigToFile handles write errors', async () => {
+    const spy = jest.spyOn(fs, 'writeFile').mockRejectedValueOnce(new Error('fail'));
+    const result = await exportConfigToFile({}, '/bad/path');
+    expect(result).toEqual({ success: false, error: 'fail' });
+    spy.mockRestore();
+  });
+
+  test('importConfigFromFile handles read errors', async () => {
+    const spy = jest.spyOn(fs, 'readFile').mockRejectedValueOnce(new Error('fail'));
+    const result = await importConfigFromFile('/bad/path');
+    expect(result).toEqual({ success: false, error: 'fail' });
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- add failure path tests for config IO helpers
- expand FloatingTerminal tests

## Testing
- `npm run test:jest:coverage:text`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_684ffcd7652c832d97816bdafa9d2e5c