### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/new/ImportStatusScreen.test.jsx
+++ b/__tests__/new/ImportStatusScreen.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ImportStatusScreen from '../../src/components/ImportStatusScreen.jsx';
+
+/** @jest-environment jsdom */
+
+describe('ImportStatusScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('runs import flow and shows completion message', async () => {
+    const onImportComplete = jest.fn(async (updateBranch, updateConfig) => {
+      updateConfig('success', 'done');
+      updateBranch('sec1', 'success', 'done');
+    });
+    render(
+      <ImportStatusScreen
+        isVisible
+        projectName="demo"
+        gitBranches={{ sec1: 'main' }}
+        onClose={() => {}}
+        onImportComplete={onImportComplete}
+      />
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(onImportComplete).toHaveBeenCalled();
+    await act(async () => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(screen.getByText('Configuration imported with 1/1 git branches switched')).toBeInTheDocument();
+  });
+});

--- a/__tests__/new/OverflowTabsDropdown.test.jsx
+++ b/__tests__/new/OverflowTabsDropdown.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OverflowTabsDropdown from '../../src/components/OverflowTabsDropdown';
+
+/** @jest-environment jsdom */
+
+describe('OverflowTabsDropdown', () => {
+  function setup(isOpen = true) {
+    const container = document.createElement('div');
+    const indicator = document.createElement('div');
+    indicator.className = 'overflow-indicator';
+    container.appendChild(indicator);
+    document.body.appendChild(container);
+    const ref = { current: container };
+    const onSelectTab = jest.fn();
+    const onShowTabInfo = jest.fn();
+    const tabs = [
+      { id: 'a', title: 'A', status: 'running' },
+      { id: 'b', title: 'B', status: 'waiting' }
+    ];
+    render(
+      <OverflowTabsDropdown
+        isOpen={isOpen}
+        tabs={tabs}
+        activeTerminalId="a"
+        onSelectTab={onSelectTab}
+        onShowTabInfo={onShowTabInfo}
+        containerRef={ref}
+      />
+    );
+    return { onSelectTab, onShowTabInfo };
+  }
+
+  test('renders list of tabs when open', () => {
+    setup();
+    const dropdown = screen.getByTestId('overflow-dropdown');
+    expect(dropdown).toBeInTheDocument();
+    const items = dropdown.querySelectorAll('.overflow-tab');
+    expect(items).toHaveLength(2);
+  });
+
+  test('triggers handlers on click', () => {
+    const { onSelectTab, onShowTabInfo } = setup();
+    const first = screen.getAllByText('A')[0].closest('.overflow-tab');
+    fireEvent.click(first);
+    expect(onSelectTab).toHaveBeenCalledWith('a');
+    const infoButton = first.querySelector('.tab-info-button');
+    fireEvent.click(infoButton);
+    expect(onShowTabInfo).toHaveBeenCalledWith('a', expect.any(Object));
+  });
+
+  test('returns null when closed or no indicator', () => {
+    const { container } = render(
+      <OverflowTabsDropdown
+        isOpen={false}
+        tabs={[]}
+        activeTerminalId="a"
+        onSelectTab={() => {}}
+        onShowTabInfo={() => {}}
+        containerRef={{ current: null }}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/new/RunButton.test.jsx
+++ b/__tests__/new/RunButton.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RunButton from '../../src/components/RunButton';
+
+/** @jest-environment jsdom */
+
+describe('RunButton component', () => {
+  test('renders RUN state and handles click', () => {
+    const onClick = jest.fn();
+    render(<RunButton projectName="demo" onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveTextContent('RUN DEMO');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  test('renders STOP state', () => {
+    render(<RunButton projectName="x" isRunning />);
+    expect(screen.getByRole('button')).toHaveTextContent('STOP X');
+  });
+
+  test('renders STOPPING state', () => {
+    render(<RunButton projectName="y" isStopping />);
+    expect(screen.getByRole('button')).toHaveTextContent('STOPPING Y');
+  });
+});

--- a/__tests__/new/TabInfoPanel.test.jsx
+++ b/__tests__/new/TabInfoPanel.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TabInfoPanel from '../../src/components/TabInfoPanel.jsx';
+
+/** @jest-environment jsdom */
+
+describe('TabInfoPanel', () => {
+  const terminal = {
+    id: 't1',
+    title: 'Test',
+    status: 'running',
+    command: 'echo hi',
+    associatedContainers: []
+  };
+
+  const position = { x: 10, y: 20 };
+
+  test('renders info and triggers handlers', () => {
+    const onClose = jest.fn();
+    const onRefresh = jest.fn();
+    const onOpenDetailsPopup = jest.fn();
+    render(
+      <TabInfoPanel
+        terminal={terminal}
+        position={position}
+        onClose={onClose}
+        onRefresh={onRefresh}
+        configState={{}}
+        noRunMode={false}
+        detailsPopupOpen={false}
+        onOpenDetailsPopup={onOpenDetailsPopup}
+        onCloseDetailsPopup={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Tab Information')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('More Details'));
+    expect(onOpenDetailsPopup).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('🔄 Refresh'));
+    expect(onRefresh).toHaveBeenCalledWith('t1');
+  });
+
+  test('shows warning when noRunMode', () => {
+    render(
+      <TabInfoPanel
+        terminal={terminal}
+        position={position}
+        onClose={() => {}}
+        onRefresh={() => {}}
+        configState={{}}
+        noRunMode={true}
+        detailsPopupOpen={false}
+        onOpenDetailsPopup={() => {}}
+        onCloseDetailsPopup={() => {}}
+      />
+    );
+    expect(screen.getByText('No Run Mode is active - refresh disabled')).toBeInTheDocument();
+    expect(screen.getByText('🔄 Refresh')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for several components
- cover RunButton, OverflowTabsDropdown, TabInfoPanel, ImportStatusScreen

## Testing
- `npm run test:jest`
- `npm run test:jest:coverage:text`

------
https://chatgpt.com/codex/tasks/task_e_685000041f80832dbac1add6dbba9ac6