### PR TITLE
Fix details popup layering

### DIFF
--- a/src/components/TabInfoPanel.jsx
+++ b/src/components/TabInfoPanel.jsx
@@ -113,7 +113,11 @@ const TabInfoPanel = ({
     if (!detailsPopupOpen) return null;
 
     return (
-      <div className="command-popup-overlay" onClick={onCloseDetailsPopup}>
+      <div
+        className="command-popup-overlay"
+        style={{ zIndex: 110000 }}
+        onClick={onCloseDetailsPopup}
+      >
         <div className="command-popup" onClick={(e) => e.stopPropagation()}>
           <div className="command-popup-header">
             <h3>More Details</h3>


### PR DESCRIPTION
## Summary
- ensure details popup overlays TabInfoPanel by giving overlay a higher z-index

## Testing
- `npm test` *(fails: unable to open X display)*

------
https://chatgpt.com/codex/tasks/task_e_68501824fad8832da3d9c0a7e1bf2fa3