### PR TITLE
Add debug flag for logs

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,14 @@
 import '@testing-library/jest-dom';
 import { performance } from 'perf_hooks';
 
+process.env.DEBUG_LOGS = 'true';
+
 global.performance = performance;
-global.IS_REACT_ACT_ENVIRONMENT = true; 
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Provide debugLog for tests
+global.debugLog = (...args) => {
+  if (process.env.DEBUG_LOGS === 'true') {
+    console.log(...args);
+  }
+};

--- a/main.js
+++ b/main.js
@@ -3,6 +3,13 @@ const path = require('path');
 const { exec } = require('child_process');
 const { generateCommandList } = require('./src/utils/evalUtils');
 
+// Simple debug logger controlled by DEBUG_LOGS env var
+global.debugLog = (...args) => {
+  if (process.env.DEBUG_LOGS === 'true') {
+    console.log(...args);
+  }
+};
+
 // Handle uncaught exceptions gracefully during tests
 if (process.env.NODE_ENV === 'test') {
   process.on('uncaughtException', (error) => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -139,7 +139,7 @@ const App = () => {
 
   // Log appNotification state changes
   React.useEffect(() => {
-    console.log('App: appNotification state updated:', appState.appNotification);
+    debugLog('App: appNotification state updated:', appState.appNotification);
   }, [appState.appNotification]);
 
   // Show loading screen while loading
@@ -322,7 +322,7 @@ const App = () => {
             terminal={terminalDataWithLiveStatus}
             position={appState.infoPanelState.position}
             onClose={floatingTerminalHandlers.closeFloatingTerminalInfoPanel}
-            onRefresh={() => console.log("Refresh clicked for floating term info - no-op")} // No-op for now
+            onRefresh={() => debugLog("Refresh clicked for floating term info - no-op")} // No-op for now
             configState={appState.configState} // Pass from App's state
             noRunMode={appState.noRunMode}     // Pass from App's state
             detailsPopupOpen={appState.infoPanelState.detailsOpen}

--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -69,7 +69,7 @@ const ConfigSection = ({
       actualValue = baseConfig[configKey];
     }
     
-    // console.log(`Visibility check: key=${configKey}, expected=${hasValue}, actual=${actualValue}, visible=${actualValue === hasValue}`);
+    // debugLog(`Visibility check: key=${configKey}, expected=${hasValue}, actual=${actualValue}, visible=${actualValue === hasValue}`);
     return actualValue === hasValue;
   };
 
@@ -180,7 +180,7 @@ const ConfigSection = ({
 
   return (
     <div className={`config-section ${borderClass} ${!config.enabled ? 'collapsed' : ''}`} id={`section-${section.id}`}>
-      {console.log(`Rendering section: ${section.id}`, { config, isAttached })}
+      {debugLog(`Rendering section: ${section.id}`, { config, isAttached })}
       <div className="section-header compact">
         <div className="section-header-left">
           <button

--- a/src/components/EnvironmentVerification.jsx
+++ b/src/components/EnvironmentVerification.jsx
@@ -39,7 +39,7 @@ const EnvironmentVerification = ({
         }
         // Then, trigger the backend refresh
         const results = await window.electron.refreshEnvironmentVerification();
-        console.log('Refreshed environment verification results:', results);
+        debugLog('Refreshed environment verification results:', results);
         // App.jsx will handle updating the statuses via its event listener
       } catch (error) {
         console.error('Error refreshing environment verification:', error);

--- a/src/components/GitBranchSwitcher.jsx
+++ b/src/components/GitBranchSwitcher.jsx
@@ -22,7 +22,7 @@ const GitBranchSwitcher = ({
 
   // Debug: Log when currentBranch changes
   useEffect(() => {
-    console.log(`GitBranchSwitcher [${projectPath}]: currentBranch changed to "${currentBranch}"`);
+    debugLog(`GitBranchSwitcher [${projectPath}]: currentBranch changed to "${currentBranch}"`);
   }, [currentBranch, projectPath]);
 
   // Update newBranchName when currentBranch prop changes (e.g., after successful checkout)

--- a/src/components/HealthReportScreen.jsx
+++ b/src/components/HealthReportScreen.jsx
@@ -11,7 +11,7 @@ const HealthReportScreen = ({
   onRefreshTerminal,
   onFocusTerminal 
 }) => {
-  console.log('HealthReportScreen: Component rendered or re-rendered.');
+  debugLog('HealthReportScreen: Component rendered or re-rendered.');
   const [containerHealth, setContainerHealth] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState(null);
@@ -48,7 +48,7 @@ const HealthReportScreen = ({
       return;
     }
     
-    console.log('HealthReportScreen: fetching container statuses...');
+    debugLog('HealthReportScreen: fetching container statuses...');
     fetchContainerStatuses();
     setIsLoading(false);
     

--- a/src/components/ImportStatusScreen.jsx
+++ b/src/components/ImportStatusScreen.jsx
@@ -67,13 +67,13 @@ const ImportStatusScreen = ({ isVisible, projectName, onClose, gitBranches, onIm
   const startImport = useCallback(async () => {
     // Prevent multiple simultaneous imports
     if (isImporting) {
-      console.log('Import already in progress, skipping...');
+      debugLog('Import already in progress, skipping...');
       return;
     }
 
     try {
       setIsImporting(true);
-      console.log('Starting import process...');
+      debugLog('Starting import process...');
       
       // Start config import
       updateConfigStatus('importing', 'Importing configuration...');

--- a/src/components/TerminalContainer.jsx
+++ b/src/components/TerminalContainer.jsx
@@ -37,7 +37,7 @@ const TerminalContainer = React.forwardRef(({ noRunMode, configState, projectNam
 
   // Log terminal state changes for debugging
   useEffect(() => {
-    console.log('TerminalContainer state updated:', terminals);
+    debugLog('TerminalContainer state updated:', terminals);
   }, [terminals]);
 
   const [tabInfoPanel, setTabInfoPanel] = useState(null);

--- a/src/hooks/useAppEffects.js
+++ b/src/hooks/useAppEffects.js
@@ -15,11 +15,11 @@ export const useAppEffects = ({
   terminalRef
 }) => {
   const triggerGitRefresh = useCallback(async () => {
-    console.log('App: Triggering targeted git status refresh...');
+    debugLog('App: Triggering targeted git status refresh...');
     if (window.electron && window.electron.refreshGitStatuses) {
       try {
         const newGitStatuses = await window.electron.refreshGitStatuses();
-        console.log('App: Received new git statuses:', newGitStatuses);
+        debugLog('App: Received new git statuses:', newGitStatuses);
         setVerificationStatuses(prev => {
           const newStatuses = { ...prev };
           for (const sectionKey in newGitStatuses) {
@@ -44,7 +44,7 @@ export const useAppEffects = ({
     
     // Listener for ongoing updates (e.g., after manual refresh)
     const removeVerificationListener = window.electron.onEnvironmentVerificationComplete((results) => {
-      console.log('App: Received environment-verification-complete event:', results);
+      debugLog('App: Received environment-verification-complete event:', results);
       if (results) {
         // Update general statuses
         if (results.general) {
@@ -83,7 +83,7 @@ export const useAppEffects = ({
     
     // Handle container cleanup before quit
     const removeQuitListener = window.electron.onStopAllContainersBeforeQuit(async () => {
-      console.log('App: Received stop-all-containers-before-quit event');
+      debugLog('App: Received stop-all-containers-before-quit event');
       if (terminalRef.current && terminalRef.current.stopAllContainers) {
         await terminalRef.current.stopAllContainers();
       }
@@ -91,7 +91,7 @@ export const useAppEffects = ({
     
     // Handle container cleanup before reload
     const removeReloadListener = window.electron.onStopAllContainersBeforeReload(async () => {
-      console.log('App: Received stop-all-containers-before-reload event');
+      debugLog('App: Received stop-all-containers-before-reload event');
       if (terminalRef.current && terminalRef.current.stopAllContainers) {
         await terminalRef.current.stopAllContainers();
       }
@@ -140,9 +140,9 @@ export const useAppEffects = ({
       // Fetch initial verification data and precache dropdowns
       const fetchInitialData = async () => {
         try {
-          console.log('App: Fetching initial environment verification data...');
+          debugLog('App: Fetching initial environment verification data...');
           const initialResults = await window.electron.getEnvironmentVerification();
-          console.log('App: Received initial environment verification data:', initialResults);
+          debugLog('App: Received initial environment verification data:', initialResults);
           
           if (initialResults) {
             if (initialResults.general) {
@@ -170,9 +170,9 @@ export const useAppEffects = ({
         
         // Now, precache the global dropdowns
         try {
-          console.log('App: Pre-caching global dropdowns...');
+          debugLog('App: Pre-caching global dropdowns...');
           await window.electron.precacheGlobalDropdowns();
-          console.log('App: Global dropdowns pre-cached successfully.');
+          debugLog('App: Global dropdowns pre-cached successfully.');
         } catch (error) {
           console.error('App: Error pre-caching global dropdowns:', error);
         } finally {

--- a/src/hooks/useAppEventHandlers.js
+++ b/src/hooks/useAppEventHandlers.js
@@ -15,7 +15,7 @@ export const useAppEventHandlers = ({
   setGlobalDropdownValues
 }) => {
   const handleVerificationStatusChange = (sectionKey, status) => {
-    console.log(`DebugPanel: Attempting to update ${sectionKey} to ${status}. This may need adjustment.`);
+    debugLog(`DebugPanel: Attempting to update ${sectionKey} to ${status}. This may need adjustment.`);
     setVerificationStatuses(prev => {
       const newStatuses = { ...prev };
       // This part needs to be careful if general is now {statuses, config}
@@ -44,13 +44,13 @@ export const useAppEventHandlers = ({
 
   // Callback for ProjectConfiguration to update App's isRunning state
   const handleProjectRunStateChange = useCallback((isRunning) => {
-    console.log('App: Project running state changed to:', isRunning);
+    debugLog('App: Project running state changed to:', isRunning);
     setAppIsProjectRunning(isRunning);
   }, [setAppIsProjectRunning]);
 
   // Function to show an app-level notification
   const showAppNotification = useCallback((message, type = 'info', autoCloseTime = 3000) => {
-    console.log('App: showAppNotification called with:', { message, type, autoCloseTime });
+    debugLog('App: showAppNotification called with:', { message, type, autoCloseTime });
     setAppNotification({
       isVisible: true,
       message,
@@ -66,7 +66,7 @@ export const useAppEventHandlers = ({
 
   // Function to reset verification statuses and config to waiting/empty
   const handleInitiateRefresh = useCallback(() => {
-    console.log('App: Initiating refresh, setting statuses to waiting and config to empty.');
+    debugLog('App: Initiating refresh, setting statuses to waiting and config to empty.');
     const resetStatuses = initializeVerificationStatuses();
     setVerificationStatuses(resetStatuses);
     setGeneralVerificationConfig([]); // Clear the config so child component shows loading/empty
@@ -84,7 +84,7 @@ export const useAppEventHandlers = ({
 
   // Callback to handle dropdown value changes from any global selector
   const handleGlobalDropdownChange = useCallback((dropdownId, value) => {
-    console.log(`App: Global dropdown '${dropdownId}' changed to:`, value);
+    debugLog(`App: Global dropdown '${dropdownId}' changed to:`, value);
     setGlobalDropdownValues(prev => ({ ...prev, [dropdownId]: value }));
     
     // Notify backend about dropdown value change for cache management

--- a/src/hooks/useConfigurationManagement.js
+++ b/src/hooks/useConfigurationManagement.js
@@ -37,7 +37,7 @@ export const useConfigurationManagement = ({
           }
         }
         
-        console.log('Exporting git branches:', gitBranches);
+        debugLog('Exporting git branches:', gitBranches);
       } catch (error) {
         console.warn('Error collecting git branches for export:', error);
       }
@@ -84,13 +84,13 @@ export const useConfigurationManagement = ({
   const performImport = useCallback(async (updateGitBranchStatus, updateConfigStatus) => {
     // Prevent multiple simultaneous imports
     if (isPerformingImport) {
-      console.log('Import already in progress, skipping...');
+      debugLog('Import already in progress, skipping...');
       return;
     }
 
     try {
       setIsPerformingImport(true);
-      console.log('Starting import process...');
+      debugLog('Starting import process...');
       
       // Use the stored import result instead of calling importConfig again
       const result = importResult;
@@ -117,7 +117,7 @@ export const useConfigurationManagement = ({
 
       // Handle git branch switching if branches were exported
       if (result.gitBranches && Object.keys(result.gitBranches).length > 0) {
-        console.log('Switching to exported git branches:', result.gitBranches);
+        debugLog('Switching to exported git branches:', result.gitBranches);
         
         // Get directory paths for sections from the about config
         const sectionDirectoryMap = {};
@@ -174,23 +174,23 @@ export const useConfigurationManagement = ({
         }
         
         // Trigger refresh and wait for it to complete
-        console.log('Import: Triggering environment refresh...');
+        debugLog('Import: Triggering environment refresh...');
         if (window.electron?.refreshEnvironmentVerification) {
           try {
             await window.electron.refreshEnvironmentVerification();
-            console.log('Import: Environment refresh completed');
+            debugLog('Import: Environment refresh completed');
           } catch (error) {
             console.warn('Import: Environment refresh failed:', error);
           }
         }
         
         // Wait for UI to update and then verify
-        console.log('Import: Waiting for UI to update...');
+        debugLog('Import: Waiting for UI to update...');
         await new Promise(resolve => setTimeout(resolve, 1500));
         
         // Verify branches after a delay to allow React state to update
         setTimeout(() => {
-          console.log('Import: Verifying branch switches after delay...');
+          debugLog('Import: Verifying branch switches after delay...');
           for (const [sectionId, switchResult] of Object.entries(branchSwitchResults)) {
             if (switchResult.skipped || !switchResult.success) {
               continue;
@@ -199,7 +199,7 @@ export const useConfigurationManagement = ({
             // Just mark as success since the git command succeeded
             // The UI will update when it's ready
             updateGitBranchStatus(sectionId, 'success', `Switched to ${switchResult.targetBranch}`);
-            console.log(`Import: Marked ${sectionId} as switched to ${switchResult.targetBranch}`);
+            debugLog(`Import: Marked ${sectionId} as switched to ${switchResult.targetBranch}`);
           }
         }, 100);
       }

--- a/src/hooks/useFixCommands.js
+++ b/src/hooks/useFixCommands.js
@@ -12,7 +12,7 @@ export const useFixCommands = ({
     if (!window.electron) return;
 
     const removeSingleVerificationListener = window.electron.onSingleVerificationUpdated?.((data) => {
-      console.log('FixCommands: Single verification updated:', data);
+      debugLog('FixCommands: Single verification updated:', data);
       
       const { verificationId, result, source, cacheKey } = data;
       
@@ -83,7 +83,7 @@ export const useFixCommands = ({
       2000
     );
     
-    console.log('Fix command started:', {
+    debugLog('Fix command started:', {
       verification: verification.id,
       command: verification.fixCommand,
       terminalId
@@ -99,7 +99,7 @@ export const useFixCommands = ({
     // Extract verification ID from terminal command ID (set when creating fix terminal)
     const verificationId = terminal.commandId;
     
-    console.log('Fix command completed:', {
+    debugLog('Fix command completed:', {
       terminalId,
       verificationId,
       status,
@@ -125,7 +125,7 @@ export const useFixCommands = ({
     try {
       if (window.electron?.rerunSingleVerification) {
         await window.electron.rerunSingleVerification(verificationId);
-        console.log('Verification re-run triggered for:', verificationId);
+        debugLog('Verification re-run triggered for:', verificationId);
       } else {
         console.warn('Single verification re-run not available, triggering full refresh');
         // Fallback to full refresh if single verification not implemented yet
@@ -142,7 +142,7 @@ export const useFixCommands = ({
 
   // Handle toggling all verification statuses for testing
   const handleToggleAllVerifications = useCallback(() => {
-    console.log('Toggling all verification statuses for testing');
+    debugLog('Toggling all verification statuses for testing');
     
     // Get the current general verification statuses (stored directly in general, not general.statuses)
     const currentGeneralStatuses = appState.verificationStatuses?.general || {};

--- a/src/hooks/useTerminals.js
+++ b/src/hooks/useTerminals.js
@@ -6,7 +6,7 @@ export const useTerminals = (configState, configSidebarCommands, noRunMode) => {
     const [activeTerminalId, setActiveTerminalId] = useState(null);
 
     const openTabs = useCallback((tabConfigs) => {
-        console.log('useTerminals: openTabs called with', tabConfigs.length, 'tabs');
+        debugLog('useTerminals: openTabs called with', tabConfigs.length, 'tabs');
         setTerminals([]);
         let firstId = null;
         const newTerminals = tabConfigs.map((tab, idx) => {
@@ -14,7 +14,7 @@ export const useTerminals = (configState, configSidebarCommands, noRunMode) => {
             if (idx === 0) firstId = terminalId;
 
             if (tab.type === 'error') {
-                console.log(`useTerminals: Creating error terminal ${terminalId}`);
+                debugLog(`useTerminals: Creating error terminal ${terminalId}`);
                 return {
                     id: terminalId,
                     title: tab.title || tab.section,
@@ -26,7 +26,7 @@ export const useTerminals = (configState, configSidebarCommands, noRunMode) => {
                 };
             } else {
                 const status = noRunMode ? 'idle' : 'pending_spawn';
-                console.log(`useTerminals: Creating terminal ${terminalId} with status ${status}, command:`, tab.command);
+                debugLog(`useTerminals: Creating terminal ${terminalId} with status ${status}, command:`, tab.command);
                 return {
                     id: terminalId,
                     title: tab.title || tab.section,
@@ -43,7 +43,7 @@ export const useTerminals = (configState, configSidebarCommands, noRunMode) => {
             }
         });
 
-        console.log('useTerminals: Setting terminals:', newTerminals);
+        debugLog('useTerminals: Setting terminals:', newTerminals);
         setTerminals(newTerminals);
         if (firstId) setActiveTerminalId(firstId);
     }, [noRunMode]);

--- a/src/main/configurationManagement.js
+++ b/src/main/configurationManagement.js
@@ -18,7 +18,7 @@ async function loadDisplaySettings() {
       projectName: sectionsConfig?.displaySettings?.projectName || 'Project',
     };
 
-    console.log('Display settings loaded successfully');
+    debugLog('Display settings loaded successfully');
     return {
       success: true,
       displaySettings,
@@ -41,7 +41,7 @@ async function getAboutConfig() {
     const configFile = await fs.readFile(CONFIG_SIDEBAR_ABOUT_PATH, 'utf-8');
     const aboutConfig = JSON.parse(configFile);
     
-    console.log('About configuration loaded successfully');
+    debugLog('About configuration loaded successfully');
     return aboutConfig;
   } catch (error) {
     console.error('Error loading about configuration:', error);
@@ -52,7 +52,7 @@ async function getAboutConfig() {
 // Function to export configuration
 async function exportConfiguration(data) {
   try {
-    console.log('Showing save dialog for configuration export...');
+    debugLog('Showing save dialog for configuration export...');
     const { canceled, filePath } = await dialog.showSaveDialog({
       title: 'Export Configuration',
       defaultPath: 'config.json',
@@ -60,7 +60,7 @@ async function exportConfiguration(data) {
     });
     
     if (canceled || !filePath) {
-      console.log('Export canceled by user');
+      debugLog('Export canceled by user');
       return { 
         success: false, 
         canceled: true,
@@ -68,11 +68,11 @@ async function exportConfiguration(data) {
       };
     }
     
-    console.log(`Exporting configuration data to: ${filePath}`);
+    debugLog(`Exporting configuration data to: ${filePath}`);
     const result = await exportConfigToFile(data, filePath);
     
     if (result.success) {
-      console.log(`Configuration exported successfully to: ${filePath}`);
+      debugLog(`Configuration exported successfully to: ${filePath}`);
       return {
         success: true,
         filePath: filePath,
@@ -99,7 +99,7 @@ async function exportConfiguration(data) {
 // Function to import configuration
 async function importConfiguration() {
   try {
-    console.log('Showing open dialog for configuration import...');
+    debugLog('Showing open dialog for configuration import...');
     const { canceled, filePaths } = await dialog.showOpenDialog({
       title: 'Import Configuration',
       properties: ['openFile'],
@@ -107,7 +107,7 @@ async function importConfiguration() {
     });
     
     if (canceled || filePaths.length === 0) {
-      console.log('Import canceled by user');
+      debugLog('Import canceled by user');
       return { 
         success: false, 
         canceled: true,
@@ -115,11 +115,11 @@ async function importConfiguration() {
       };
     }
     
-    console.log(`Importing configuration from file: ${filePaths[0]}`);
+    debugLog(`Importing configuration from file: ${filePaths[0]}`);
     const result = await importConfigFromFile(filePaths[0]);
     
     if (result.success) {
-      console.log('Configuration imported successfully');
+      debugLog('Configuration imported successfully');
       // Spread the imported data directly like the original version
       // This ensures configState, attachState, globalDropdownValues, gitBranches are top-level properties
       return {
@@ -152,7 +152,7 @@ async function loadSectionConfiguration(sectionFilePath) {
     const configFile = await fs.readFile(absolutePath, 'utf-8');
     const sectionConfig = JSON.parse(configFile);
     
-    console.log(`Section configuration loaded: ${sectionFilePath}`);
+    debugLog(`Section configuration loaded: ${sectionFilePath}`);
     return {
       success: true,
       config: sectionConfig
@@ -173,7 +173,7 @@ async function saveConfiguration(configPath, data) {
     const configString = JSON.stringify(data, null, 2);
     await fs.writeFile(configPath, configString, 'utf-8');
     
-    console.log(`Configuration saved to: ${configPath}`);
+    debugLog(`Configuration saved to: ${configPath}`);
     return {
       success: true,
       filePath: configPath,

--- a/src/main/containerManagement.js
+++ b/src/main/containerManagement.js
@@ -10,7 +10,7 @@ async function stopContainers(containerNames, mainWindow = null) {
     };
   }
 
-  console.log('Attempting to stop containers:', containerNames);
+  debugLog('Attempting to stop containers:', containerNames);
 
   const stopPromises = containerNames.map(containerName => {
     return stopSingleContainer(containerName, mainWindow)
@@ -53,7 +53,7 @@ async function stopSingleContainer(containerName, mainWindow = null) {
   
   return new Promise((resolve) => {
     const command = `docker stop "${containerName}"`;
-    console.log(`Executing: ${command}`);
+    debugLog(`Executing: ${command}`);
 
     exec(command, { timeout: 30000 }, (error, stdout, stderr) => {
       if (error) {
@@ -73,7 +73,7 @@ async function stopSingleContainer(containerName, mainWindow = null) {
           stderr: stderr.trim()
         });
       } else {
-        console.log(`Successfully stopped container ${containerName}`);
+        debugLog(`Successfully stopped container ${containerName}`);
         // Emit container terminated event with success
         if (mainWindow && !mainWindow.isDestroyed()) {
           mainWindow.webContents.send('container-terminated', { 
@@ -99,7 +99,7 @@ async function getContainerStatus(containerName) {
 
   return new Promise((resolve) => {
     const command = `docker inspect --format='{{.State.Status}}' "${containerName}"`;
-    console.log(`Checking container status: ${command}`);
+    debugLog(`Checking container status: ${command}`);
 
     exec(command, { timeout: 5000 }, (error, stdout, stderr) => {
       if (error) {
@@ -108,7 +108,7 @@ async function getContainerStatus(containerName) {
         resolve('unknown');
       } else {
         const status = stdout.trim();
-        console.log(`Container ${containerName} status: ${status}`);
+        debugLog(`Container ${containerName} status: ${status}`);
         resolve(status || 'unknown');
       }
     });
@@ -131,7 +131,7 @@ async function listContainers(options = {}) {
   }
 
   return new Promise((resolve) => {
-    console.log(`Listing containers: ${command}`);
+    debugLog(`Listing containers: ${command}`);
 
     exec(command, { timeout: 10000 }, (error, stdout, stderr) => {
       if (error) {
@@ -187,7 +187,7 @@ async function removeContainers(containerNames, options = {}) {
   }
 
   const { force = false, volumes = false } = options;
-  console.log('Attempting to remove containers:', containerNames);
+  debugLog('Attempting to remove containers:', containerNames);
   const results = [];
 
   for (const containerName of containerNames) {
@@ -228,7 +228,7 @@ async function removeSingleContainer(containerName, options = {}) {
   command += ` "${containerName}"`;
 
   return new Promise((resolve) => {
-    console.log(`Executing: ${command}`);
+    debugLog(`Executing: ${command}`);
 
     exec(command, { timeout: 30000 }, (error, stdout, stderr) => {
       if (error) {
@@ -240,7 +240,7 @@ async function removeSingleContainer(containerName, options = {}) {
           stderr: stderr.trim()
         });
       } else {
-        console.log(`Successfully removed container ${containerName}`);
+        debugLog(`Successfully removed container ${containerName}`);
         resolve({
           success: true,
           stdout: stdout.trim(),
@@ -259,7 +259,7 @@ async function isDockerAvailable() {
         console.warn('Docker not available:', error.message);
         resolve(false);
       } else {
-        console.log('Docker version:', stdout.trim());
+        debugLog('Docker version:', stdout.trim());
         resolve(true);
       }
     });

--- a/src/main/dropdownManagement.js
+++ b/src/main/dropdownManagement.js
@@ -39,13 +39,13 @@ async function getDropdownOptions(config) {
 
   // Check cache first
   if (dropdownCache[cacheKey]) {
-    console.log(`Returning cached options for dropdown ${id}`);
+    debugLog(`Returning cached options for dropdown ${id}`);
     return dropdownCache[cacheKey];
   }
 
   // Mark as loading
   dropdownLoadingState[cacheKey] = true;
-  console.log(`Fetching dropdown options for ${id} with command: ${resolvedCommand}`);
+  debugLog(`Fetching dropdown options for ${id} with command: ${resolvedCommand}`);
 
   try {
     const result = await new Promise((resolve) => {
@@ -74,7 +74,7 @@ async function getDropdownOptions(config) {
     
     const resultData = { options };
     dropdownCache[cacheKey] = resultData;
-    console.log(`Cached ${options.length} options for dropdown ${id}`);
+    debugLog(`Cached ${options.length} options for dropdown ${id}`);
     return resultData;
 
   } catch (error) {
@@ -88,7 +88,7 @@ async function getDropdownOptions(config) {
 }
 
 async function precacheGlobalDropdowns() {
-    console.log('Starting global dropdown pre-caching...');
+    debugLog('Starting global dropdown pre-caching...');
     try {
         const configPath = path.join(__dirname, '..', 'generalEnvironmentVerifications.json');
         const configData = await fs.readFile(configPath, 'utf-8');
@@ -97,12 +97,12 @@ async function precacheGlobalDropdowns() {
         const globalDropdowns = config?.header?.dropdownSelectors || [];
 
         if (globalDropdowns.length === 0) {
-            console.log('No global dropdowns found to pre-cache.');
+            debugLog('No global dropdowns found to pre-cache.');
             return { success: true, precached: 0 };
         }
 
         const precachePromises = globalDropdowns.map(dropdownConfig => {
-            console.log(`Pre-caching a global dropdown: ${dropdownConfig.id}`);
+            debugLog(`Pre-caching a global dropdown: ${dropdownConfig.id}`);
             return getDropdownOptions({
                 id: dropdownConfig.id,
                 command: dropdownConfig.command,
@@ -112,7 +112,7 @@ async function precacheGlobalDropdowns() {
         });
 
         await Promise.all(precachePromises);
-        console.log(`Global dropdown pre-caching complete. Cached ${globalDropdowns.length} dropdowns.`);
+        debugLog(`Global dropdown pre-caching complete. Cached ${globalDropdowns.length} dropdowns.`);
         return { success: true, precached: globalDropdowns.length };
 
     } catch (error) {
@@ -123,7 +123,7 @@ async function precacheGlobalDropdowns() {
 
 // Function to handle dropdown value changes
 function handleDropdownValueChange(dropdownId, value) {
-  console.log(`Dropdown ${dropdownId} value changed to: ${value}`);
+  debugLog(`Dropdown ${dropdownId} value changed to: ${value}`);
   
   // Clear related caches if needed
   // This is a simple implementation - you might want more sophisticated cache invalidation
@@ -133,7 +133,7 @@ function handleDropdownValueChange(dropdownId, value) {
   });
   
   if (keysToRemove.length > 0) {
-    console.log(`Cleared ${keysToRemove.length} cache entries for dropdown ${dropdownId}`);
+    debugLog(`Cleared ${keysToRemove.length} cache entries for dropdown ${dropdownId}`);
   }
 }
 
@@ -146,12 +146,12 @@ function clearDropdownCache(dropdownId = null) {
       delete dropdownCache[key];
       delete dropdownLoadingState[key];
     });
-    console.log(`Cleared cache for dropdown ${dropdownId}`);
+    debugLog(`Cleared cache for dropdown ${dropdownId}`);
   } else {
     // Clear all cache
     dropdownCache = {};
     dropdownLoadingState = {};
-    console.log('Cleared all dropdown cache');
+    debugLog('Cleared all dropdown cache');
   }
 }
 

--- a/src/main/environmentVerification.js
+++ b/src/main/environmentVerification.js
@@ -23,7 +23,7 @@ const VERIFICATIONS_CONFIG_PATH = path.join(__dirname, '../generalEnvironmentVer
 const CONFIG_SIDEBAR_ABOUT_PATH = path.join(__dirname, '../configurationSidebarAbout.json');
 
 const execCommand = async (commandString) => {
-  console.log(`Executing command: ${commandString}`);
+  debugLog(`Executing command: ${commandString}`);
   return new Promise((resolve) => {
     // Set a reasonable timeout for commands
     const timeout = setTimeout(() => {
@@ -45,18 +45,18 @@ const execCommand = async (commandString) => {
 
       if (nvmDir && fsSync.existsSync(path.join(nvmDir, 'nvm.sh'))) {
         nvmScriptPath = path.join(nvmDir, 'nvm.sh');
-        console.log(`Found nvm.sh via NVM_DIR: ${nvmScriptPath}`);
+        debugLog(`Found nvm.sh via NVM_DIR: ${nvmScriptPath}`);
       } else if (fsSync.existsSync(homeNvmPath)) {
         nvmScriptPath = homeNvmPath;
-        console.log(`Found nvm.sh at default home location: ${nvmScriptPath}`);
+        debugLog(`Found nvm.sh at default home location: ${nvmScriptPath}`);
       } else if (process.platform === 'darwin' && fsSync.existsSync(homebrewNvmPath)) {
         nvmScriptPath = homebrewNvmPath;
-        console.log(`Found nvm.sh at Homebrew location: ${nvmScriptPath}`);
+        debugLog(`Found nvm.sh at Homebrew location: ${nvmScriptPath}`);
       }
 
       if (nvmScriptPath) {
         finalCommand = `. "${nvmScriptPath}" && ${commandString}`; // Ensure path with spaces is quoted
-        console.log(`Modified nvm command to: ${finalCommand}`);
+        debugLog(`Modified nvm command to: ${finalCommand}`);
       } else {
         console.warn('nvm.sh not found via NVM_DIR, ~/.nvm/nvm.sh, or Homebrew path. Running nvm command without explicit sourcing.');
       }
@@ -77,7 +77,7 @@ const execCommand = async (commandString) => {
         console.warn(`Command failed: ${commandString}. Stderr: "${sStderr}". Error:`, error.message);
         resolve({ success: false, stdout: sStdout, stderr: sStderr });
       } else {
-        console.log(`Command succeeded: ${commandString}. Stdout: "${sStdout}"`);
+        debugLog(`Command succeeded: ${commandString}. Stdout: "${sStdout}"`);
         resolve({ success: true, stdout: sStdout, stderr: sStderr });
       }
     });
@@ -118,7 +118,7 @@ async function verifyEnvironment(mainWindow = null) {
   }
 
   isVerifyingEnvironment = true;
-  console.log('Starting full environment verification process...');
+  debugLog('Starting full environment verification process...');
 
   // For generalResults, we'll populate statuses directly. The config will be stored alongside.
   const generalResultsStatuses = {};
@@ -326,7 +326,7 @@ async function verifyEnvironment(mainWindow = null) {
     // Handle sections that skip verification
     if (skipVerification) {
       environmentCaches[cacheKey] = { status: 'no_specific_checks' };
-      console.log(`${sectionId} Environment Cache:`, environmentCaches[cacheKey]);
+      debugLog(`${sectionId} Environment Cache:`, environmentCaches[cacheKey]);
       return;
     }
     
@@ -419,7 +419,7 @@ async function verifyEnvironment(mainWindow = null) {
       gitBranch
     };
     
-    console.log(`${sectionId} Environment Cache:`, environmentCaches[cacheKey]);
+    debugLog(`${sectionId} Environment Cache:`, environmentCaches[cacheKey]);
     
     // Update progress for section completion
     completedCount++;
@@ -435,10 +435,10 @@ async function verifyEnvironment(mainWindow = null) {
   // Wait for all sections to complete
   await Promise.all(sectionPromises);
 
-  console.log('Overall Environment Verification Completed. Composite Results:\n', JSON.stringify(environmentCaches, null, 2));
+  debugLog('Overall Environment Verification Completed. Composite Results:\n', JSON.stringify(environmentCaches, null, 2));
 
   isVerifyingEnvironment = false;
-  console.log('Environment verification completed.');
+  debugLog('Environment verification completed.');
   
   // Send completion event to frontend
   if (mainWindow) {
@@ -450,7 +450,7 @@ async function verifyEnvironment(mainWindow = null) {
 
 // Function to refresh environment verification
 async function refreshEnvironmentVerification(mainWindow = null) {
-  console.log('Forcefully refreshing all environment verification data...');
+  debugLog('Forcefully refreshing all environment verification data...');
 
   // Reset verification state flag to ensure the process runs
   isVerifyingEnvironment = false;
@@ -468,7 +468,7 @@ async function refreshEnvironmentVerification(mainWindow = null) {
     mainWindow.webContents.send('environment-verification-complete', { ...newResults, discoveredVersions });
   }
 
-  console.log('Environment verification refresh has fully completed.');
+  debugLog('Environment verification refresh has fully completed.');
   return { ...newResults, discoveredVersions };
 }
 
@@ -499,7 +499,7 @@ function getEnvironmentExportData() {
 
 // Function to re-run a single verification by ID
 async function rerunSingleVerification(verificationId, mainWindow = null) {
-  console.log(`Re-running single verification: ${verificationId}`);
+  debugLog(`Re-running single verification: ${verificationId}`);
   
   let found = false;
   let updatedData = null;
@@ -714,7 +714,7 @@ async function rerunSingleVerification(verificationId, mainWindow = null) {
       return { success: false, error: 'Verification not found' };
     }
     
-    console.log(`Single verification ${verificationId} completed with result: ${updatedData.result}`);
+    debugLog(`Single verification ${verificationId} completed with result: ${updatedData.result}`);
     
     // Send updated result to frontend
     if (mainWindow) {

--- a/src/main/gitManagement.js
+++ b/src/main/gitManagement.js
@@ -26,7 +26,7 @@ const getGitBranch = async (relativePath) => {
         return;
       }
       const branchName = stdout.trim();
-      console.log(`Git branch for ${absolutePath}: ${branchName}`);
+      debugLog(`Git branch for ${absolutePath}: ${branchName}`);
       gitBranchCache[relativePath] = branchName; // Cache the result
       resolve(branchName);
     });
@@ -39,7 +39,7 @@ const checkoutGitBranch = async (projectPath, branchName) => {
   
   return new Promise((resolve) => {
     const command = `git -C "${absolutePath}" checkout "${branchName}"`;
-    console.log(`Executing git checkout: ${command}`);
+    debugLog(`Executing git checkout: ${command}`);
     
     exec(command, { timeout: 10000 }, (error, stdout, stderr) => {
       if (error) {
@@ -53,7 +53,7 @@ const checkoutGitBranch = async (projectPath, branchName) => {
         return;
       }
       
-      console.log(`Git checkout successful for ${absolutePath} to branch ${branchName}`);
+      debugLog(`Git checkout successful for ${absolutePath} to branch ${branchName}`);
       
       // Clear cache for this path so next getGitBranch call will fetch fresh data
       delete gitBranchCache[projectPath];
@@ -74,7 +74,7 @@ const listLocalGitBranches = async (projectPath) => {
   
   return new Promise((resolve) => {
     const command = `git -C "${absolutePath}" branch --format="%(refname:short)"`;
-    console.log(`Listing local branches: ${command}`);
+    debugLog(`Listing local branches: ${command}`);
     
     exec(command, { timeout: 5000 }, (error, stdout, stderr) => {
       if (error) {
@@ -88,7 +88,7 @@ const listLocalGitBranches = async (projectPath) => {
       }
       
       const branches = stdout.trim().split('\n').filter(branch => branch.trim() !== '');
-      console.log(`Found ${branches.length} local branches for ${absolutePath}:`, branches);
+      debugLog(`Found ${branches.length} local branches for ${absolutePath}:`, branches);
       
       resolve({
         success: true,
@@ -116,7 +116,7 @@ const getGitBranchCache = () => {
 };
 
 async function refreshGitBranches() {
-    console.log('Refreshing git branch statuses...');
+    debugLog('Refreshing git branch statuses...');
     clearGitBranchCache();
 
     let configSidebarAbout = [];
@@ -138,7 +138,7 @@ async function refreshGitBranches() {
     });
 
     await Promise.all(branchPromises);
-    console.log('Git branch refresh complete.');
+    debugLog('Git branch refresh complete.');
     return refreshedBranches;
 }
 

--- a/src/main/ptyManagement.js
+++ b/src/main/ptyManagement.js
@@ -9,7 +9,7 @@ try {
 } catch (error) {
   console.warn('node-pty module failed to load:', error.message);
   if (process.env.NODE_ENV === 'test') {
-    console.log('Continuing in test mode without node-pty...');
+    debugLog('Continuing in test mode without node-pty...');
     // Create a mock pty object for tests
     pty = {
       spawn: () => {
@@ -348,7 +348,7 @@ function spawnPTY(command, terminalId, cols = 80, rows = 24, projectRoot, mainWi
   } else {
     shell = process.env.SHELL || '/bin/bash';
   }
-  console.log(`Using shell: ${shell} with args: [${shellArgs.join(', ')}] for PTY on platform: ${os.platform()}`);
+  debugLog(`Using shell: ${shell} with args: [${shellArgs.join(', ')}] for PTY on platform: ${os.platform()}`);
 
   let ptyProcess;
   try {
@@ -371,7 +371,7 @@ function spawnPTY(command, terminalId, cols = 80, rows = 24, projectRoot, mainWi
   }
 
   activeProcesses[terminalId] = ptyProcess;
-  console.log(`PTY spawned for terminal ${terminalId} with PID ${ptyProcess.pid}, executing: ${command}`);
+  debugLog(`PTY spawned for terminal ${terminalId} with PID ${ptyProcess.pid}, executing: ${command}`);
 
   // Execute the command after a short delay to let the shell initialize
   setTimeout(() => {
@@ -540,7 +540,7 @@ function killProcess(terminalId, mainWindow) {
   const ptyProcess = activeProcesses[terminalId];
 
   if (ptyProcess) {
-    console.log(`Attempting to kill PTY process with PID ${ptyProcess.pid} for terminal ${terminalId}`);
+    debugLog(`Attempting to kill PTY process with PID ${ptyProcess.pid} for terminal ${terminalId}`);
     
     // Emit terminating event
     if (mainWindow) {
@@ -550,10 +550,10 @@ function killProcess(terminalId, mainWindow) {
     try {
       if (os.platform() === 'win32') {
         ptyProcess.kill(); // Default behavior for Windows
-        console.log(`ptyProcess.kill() called for Windows PID ${ptyProcess.pid} for terminal ${terminalId}`);
+        debugLog(`ptyProcess.kill() called for Windows PID ${ptyProcess.pid} for terminal ${terminalId}`);
       } else {
         ptyProcess.kill('SIGKILL'); // Use SIGKILL for macOS/Linux
-        console.log(`ptyProcess.kill('SIGKILL') called for PID ${ptyProcess.pid} for terminal ${terminalId}`);
+        debugLog(`ptyProcess.kill('SIGKILL') called for PID ${ptyProcess.pid} for terminal ${terminalId}`);
       }
       // The onExit handler will handle cleanup and notification
     } catch (e) {
@@ -567,7 +567,7 @@ function killProcess(terminalId, mainWindow) {
       }
     }
   } else {
-    console.log(`No active PTY process found for terminal ${terminalId} to kill.`);
+    debugLog(`No active PTY process found for terminal ${terminalId} to kill.`);
     // Still emit terminated event even if process not found
     if (mainWindow) {
       mainWindow.webContents.send('process-terminated', { terminalId });
@@ -607,7 +607,7 @@ function killAllPTYProcesses() {
     const ptyProcess = activeProcesses[terminalId];
     if (ptyProcess) {
       try {
-        console.log(`Killing PTY for terminal ${terminalId} with PID ${ptyProcess.pid}`);
+        debugLog(`Killing PTY for terminal ${terminalId} with PID ${ptyProcess.pid}`);
         ptyProcess.kill();
         delete activeProcesses[terminalId];
         killedCount++;
@@ -617,7 +617,7 @@ function killAllPTYProcesses() {
     }
   }
 
-  console.log(`Killed ${killedCount} PTY processes during cleanup`);
+  debugLog(`Killed ${killedCount} PTY processes during cleanup`);
   return { killedCount, totalCount: terminalIds.length };
 }
 

--- a/src/main/windowManagement.js
+++ b/src/main/windowManagement.js
@@ -5,7 +5,7 @@ let mainWindow = null;
 
 // Function to create the main application window
 function createWindow() {
-  console.log('Creating main window...');
+  debugLog('Creating main window...');
   
   // Check if running in test/headless mode
   const isTestMode = process.env.HEADLESS === 'true';
@@ -30,7 +30,7 @@ function createWindow() {
     windowOptions.maximizable = false;
     windowOptions.closable = true;
     windowOptions.focusable = false;
-    console.log('Creating invisible window for test mode');
+    debugLog('Creating invisible window for test mode');
   }
 
   // Create the browser window
@@ -41,7 +41,7 @@ function createWindow() {
 
   // Show window when ready to prevent visual flash
   mainWindow.once('ready-to-show', () => {
-    console.log('Main window ready to show');
+    debugLog('Main window ready to show');
     if (!isTestMode) {
       mainWindow.show();
       
@@ -54,41 +54,41 @@ function createWindow() {
 
   // Handle window closed
   mainWindow.on('closed', () => {
-    console.log('Main window closed');
+    debugLog('Main window closed');
     mainWindow = null;
   });
 
   // Handle window focus events
   mainWindow.on('focus', () => {
-    console.log('Main window focused');
+    debugLog('Main window focused');
   });
 
   mainWindow.on('blur', () => {
-    console.log('Main window blurred');
+    debugLog('Main window blurred');
   });
 
   // Handle window resize events
   mainWindow.on('resize', () => {
     const [width, height] = mainWindow.getSize();
-    console.log(`Main window resized to ${width}x${height}`);
+    debugLog(`Main window resized to ${width}x${height}`);
   });
 
   // Handle window maximize/unmaximize events
   mainWindow.on('maximize', () => {
-    console.log('Main window maximized');
+    debugLog('Main window maximized');
   });
 
   mainWindow.on('unmaximize', () => {
-    console.log('Main window unmaximized');
+    debugLog('Main window unmaximized');
   });
 
   // Handle window minimize/restore events
   mainWindow.on('minimize', () => {
-    console.log('Main window minimized');
+    debugLog('Main window minimized');
   });
 
   mainWindow.on('restore', () => {
-    console.log('Main window restored');
+    debugLog('Main window restored');
   });
 
   // Prevent navigation away from the app
@@ -105,11 +105,11 @@ function createWindow() {
 
   // Handle new window creation
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    console.log('Preventing new window creation for:', url);
+    debugLog('Preventing new window creation for:', url);
     return { action: 'deny' };
   });
 
-  console.log('Main window created successfully');
+  debugLog('Main window created successfully');
   return mainWindow;
 }
 
@@ -121,7 +121,7 @@ function getMainWindow() {
 // Function to open developer tools
 function openDevTools() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Opening developer tools');
+    debugLog('Opening developer tools');
     mainWindow.webContents.openDevTools();
     return { success: true };
   } else {
@@ -133,7 +133,7 @@ function openDevTools() {
 // Function to reload the application
 function reloadApp() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Reloading application');
+    debugLog('Reloading application');
     mainWindow.reload();
     return { success: true };
   } else {
@@ -145,7 +145,7 @@ function reloadApp() {
 // Function to close the main window
 function closeMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Closing main window');
+    debugLog('Closing main window');
     mainWindow.close();
     return { success: true };
   } else {
@@ -157,7 +157,7 @@ function closeMainWindow() {
 // Function to minimize the main window
 function minimizeMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Minimizing main window');
+    debugLog('Minimizing main window');
     mainWindow.minimize();
     return { success: true };
   } else {
@@ -169,10 +169,10 @@ function minimizeMainWindow() {
 function maximizeMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (mainWindow.isMaximized()) {
-      console.log('Unmaximizing main window');
+      debugLog('Unmaximizing main window');
       mainWindow.unmaximize();
     } else {
-      console.log('Maximizing main window');
+      debugLog('Maximizing main window');
       mainWindow.maximize();
     }
     return { success: true, isMaximized: mainWindow.isMaximized() };
@@ -184,7 +184,7 @@ function maximizeMainWindow() {
 // Function to show the main window
 function showMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Showing main window');
+    debugLog('Showing main window');
     mainWindow.show();
     mainWindow.focus();
     return { success: true };
@@ -196,7 +196,7 @@ function showMainWindow() {
 // Function to hide the main window
 function hideMainWindow() {
   if (mainWindow && !mainWindow.isDestroyed()) {
-    console.log('Hiding main window');
+    debugLog('Hiding main window');
     mainWindow.hide();
     return { success: true };
   } else {
@@ -250,7 +250,7 @@ function setWindowState(state) {
       mainWindow.minimize();
     }
     
-    console.log('Window state updated successfully');
+    debugLog('Window state updated successfully');
     return { success: true };
   } catch (error) {
     console.error('Error setting window state:', error);

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -3,9 +3,17 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles/index.css';
 
+// Simple debug logger controlled by DEBUG_LOGS env var
+window.debugLog = (...args) => {
+  // Avoid ReferenceError if process is not available in the renderer
+  if (typeof process !== 'undefined' && process.env && process.env.DEBUG_LOGS === 'true') {
+    console.log(...args);
+  }
+};
+
 // Initialize the UI when the page loads
 document.addEventListener('DOMContentLoaded', () => {
-  console.log('DOM loaded, initializing React UI...');
+  debugLog('DOM loaded, initializing React UI...');
   
   // Add a small delay to ensure the DOM is fully rendered
   setTimeout(() => {
@@ -23,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const root = createRoot(container);
         root.render(<App />);
       }
-      console.log('React UI initialization complete');
+      debugLog('React UI initialization complete');
     } catch (error) {
       console.error('Error initializing React UI:', error);
     }


### PR DESCRIPTION
## Summary
- wrap many `console.log` statements with a new `debugLog` helper
- provide global debugLog in `main.js` and renderer entry
- ensure tests define DEBUG_LOGS and helper in `jest.setup.js`
- avoid `process` reference errors in the renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850116058a8832daa5898858b79becd