### PR TITLE
Fix renderer crash with missing process env

### DIFF
--- a/electron-preload.js
+++ b/electron-preload.js
@@ -13,6 +13,11 @@ const eventListeners = {
 // Create a special direct output handler that bypasses the callback stack
 let directOutputCallback = null;
 
+// Expose limited environment variables needed by the renderer
+contextBridge.exposeInMainWorld('env', {
+  DEBUG_LOGS: process.env.DEBUG_LOGS
+});
+
 contextBridge.exposeInMainWorld('electron', {
   // Add the new command generation handler
   getCommandForSection: (data) => ipcRenderer.invoke('get-command-for-section', data),

--- a/src/renderer.jsx
+++ b/src/renderer.jsx
@@ -5,7 +5,9 @@ import './styles/index.css';
 
 // Simple debug logger controlled by DEBUG_LOGS env var
 window.debugLog = (...args) => {
-  if (process.env.DEBUG_LOGS === 'true') {
+  const debugEnv = (typeof process !== 'undefined' && process.env && process.env.DEBUG_LOGS) ||
+                   (window.env && window.env.DEBUG_LOGS);
+  if (debugEnv === 'true') {
     console.log(...args);
   }
 };


### PR DESCRIPTION
## Summary
- expose DEBUG_LOGS env var from preload script
- guard against undefined process in `debugLog`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68501d14c50c832dae57c0a06b09b52b