### PR TITLE
Fix StoppingStatusScreen state reset

### DIFF
--- a/__tests__/StoppingStatusScreen.test.jsx
+++ b/__tests__/StoppingStatusScreen.test.jsx
@@ -329,6 +329,48 @@ describe('StoppingStatusScreen', () => {
     });
   });
 
+  describe('State reset between runs', () => {
+    test('should not show close button immediately when reopened', async () => {
+      const terminals = [
+        {
+          id: 'term1',
+          title: 'Terminal 1',
+          associatedContainers: [],
+        },
+      ];
+
+      const { rerender } = render(
+        <StoppingStatusScreen {...defaultProps} terminals={terminals} />
+      );
+
+      // Trigger timeout to show close button
+      act(() => {
+        jest.advanceTimersByTime(20000);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Close')).toBeInTheDocument();
+      });
+
+      // Hide the component
+      rerender(
+        <StoppingStatusScreen
+          {...defaultProps}
+          terminals={terminals}
+          isVisible={false}
+        />
+      );
+
+      // Show again
+      rerender(
+        <StoppingStatusScreen {...defaultProps} terminals={terminals} />
+      );
+
+      // Close button should not be visible immediately
+      expect(screen.queryByText('Close')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Edge cases', () => {
     test('should handle invalid container names gracefully', async () => {
       const terminals = [

--- a/src/components/StoppingStatusScreen.jsx
+++ b/src/components/StoppingStatusScreen.jsx
@@ -30,6 +30,8 @@ const StoppingStatusScreen = ({ terminals, isVisible, projectName, onClose }) =>
       // Reset status when not visible
       setTerminationStatus({ processes: {}, containers: {} });
       setIsComplete(false);
+      setIsTimeoutReached(false);
+      setIsInitialized(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- reset timeout state when stopping screen hides
- add regression test for reopening StoppingStatusScreen

## Testing
- `npm test` *(fails: cannot close electron app)*

------
https://chatgpt.com/codex/tasks/task_e_6850199ba728832daf6227ec9b6d8001