### PR TITLE
Add more unit tests

### DIFF
--- a/__tests__/mainUtils.extra.test.js
+++ b/__tests__/mainUtils.extra.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment node */
+const fs = require('fs').promises;
+const path = require('path');
+const os = require('os');
+const { resolveEnvVars, checkPathExists } = require('../src/main/mainUtils');
+
+describe('mainUtils additional', () => {
+  test('resolveEnvVars returns input when not a string', () => {
+    expect(resolveEnvVars(123)).toBe(123);
+  });
+
+  test('checkPathExists with file and mismatched type', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'file-'));
+    const file = path.join(tmp, 'f.txt');
+    await fs.writeFile(file, 'hi');
+    expect(await checkPathExists(tmp, 'f.txt', 'file')).toBe('valid');
+    expect(await checkPathExists(tmp, 'f.txt', 'directory')).toBe('invalid');
+  });
+
+  test('checkPathExists without type', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dir-'));
+    expect(await checkPathExists(dir, '.', null)).toBe('valid');
+  });
+});

--- a/__tests__/useTabManagement.extra.test.js
+++ b/__tests__/useTabManagement.extra.test.js
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+import { useTabManagement } from '../src/hooks/useTabManagement';
+
+describe('useTabManagement outside click', () => {
+  test('closes overflow when clicking outside', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    const overflowButton = document.createElement('button');
+    overflowButton.className = 'overflow-indicator';
+    container.appendChild(overflowButton);
+    document.body.appendChild(container);
+    const dropdown = document.createElement('div');
+    dropdown.dataset.testid = 'overflow-dropdown';
+    document.body.appendChild(dropdown);
+
+    const ref = { current: container };
+    const { result } = renderHook(() => useTabManagement(ref, [], null));
+    act(() => result.current.toggleOverflowTabs());
+    act(() => jest.runAllTimers());
+    document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    expect(result.current.overflowTabsOpen).toBe(false);
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/useTerminals.extra.test.js
+++ b/__tests__/useTerminals.extra.test.js
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+import { renderHook, act } from '@testing-library/react';
+jest.mock('../src/utils/evalUtils', () => ({
+  evaluateCommandCondition: jest.fn(() => true)
+}));
+import { useTerminals } from '../src/hooks/useTerminals';
+import { evaluateCommandCondition } from '../src/utils/evalUtils';
+
+describe('useTerminals extra scenarios', () => {
+  beforeEach(() => {
+    window.electron = {
+      killProcess: jest.fn(),
+      stopContainers: jest.fn().mockResolvedValue()
+    };
+  });
+  afterEach(() => {
+    delete window.electron;
+    jest.restoreAllMocks();
+  });
+
+  test('handleRefreshTab stops associated containers', async () => {
+    const { result } = renderHook(() => useTerminals({}, [], false));
+    act(() => {
+      result.current.openTabs([{ command: 'c', sectionId: 's', associatedContainers: ['a','b'] }]);
+    });
+    const id = result.current.terminals[0].id;
+    await act(async () => {
+      await result.current.handleRefreshTab(id);
+    });
+    expect(window.electron.stopContainers).toHaveBeenCalledWith(['a','b']);
+    expect(window.electron.killProcess).toHaveBeenCalledWith(id);
+  });
+
+  test('handleCloseTab stops containers and clears active id', async () => {
+    const { result } = renderHook(() => useTerminals({}, [], false));
+    act(() => {
+      result.current.openTabs([{ command:'x', sectionId:'sec', associatedContainers:['c'] }]);
+    });
+    const id = result.current.terminals[0].id;
+    await act(async () => {
+      await result.current.handleCloseTab(id);
+    });
+    expect(window.electron.stopContainers).toHaveBeenCalledWith(['c']);
+    expect(result.current.activeTerminalId).toBe(null);
+  });
+});

--- a/__tests__/useTitleOverflow.test.js
+++ b/__tests__/useTitleOverflow.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import { useTitleOverflow } from '../src/hooks/useTitleOverflow';
+
+global.ResizeObserver = class {
+  constructor(cb){ this.cb=cb; }
+  observe(){ this.cb(); }
+  disconnect(){}
+};
+
+describe('useTitleOverflow', () => {
+  test('detects overflow', () => {
+    const tab = document.createElement('div');
+    Object.defineProperty(tab, 'clientWidth', { value: 100 });
+    const title = document.createElement('span');
+    Object.defineProperty(title, 'scrollWidth', { value: 120 });
+    const { result } = renderHook(() => useTitleOverflow({current:tab}, {current:title}, true));
+    expect(result.current).toBe(true);
+  });
+
+  test('detects no overflow', () => {
+    const tab = document.createElement('div');
+    Object.defineProperty(tab, 'clientWidth', { value: 200 });
+    const title = document.createElement('span');
+    Object.defineProperty(title, 'scrollWidth', { value: 50 });
+    const { result } = renderHook(() => useTitleOverflow({current:tab}, {current:title}, true));
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- expand unit tests for mainUtils, useTerminals, useTabManagement, and useTitleOverflow hooks

## Testing
- `npm run test:jest:coverage:text`


------
https://chatgpt.com/codex/tasks/task_e_685045fb2330832d9eaee32636de3290