### PR TITLE
Add tests for mainUtils utility functions

### DIFF
--- a/__tests__/mainUtils.extra.test.js
+++ b/__tests__/mainUtils.extra.test.js
@@ -21,4 +21,13 @@ describe('mainUtils additional', () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dir-'));
     expect(await checkPathExists(dir, '.', null)).toBe('valid');
   });
+
+  test('checkPathExists without type returns invalid for missing path', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dir-'));
+    expect(await checkPathExists(dir, 'nope.txt')).toBe('invalid');
+  });
+
+  test('resolveEnvVars returns empty string for empty input', () => {
+    expect(resolveEnvVars('')).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- increase coverage for `resolveEnvVars` and `checkPathExists`

## Testing
- `DEBUG_LOGS=false npx jest --config=jest.config.js --coverage --coverageDirectory=coverage/prod --runTestsByPath __tests__/mainUtils.test.js __tests__/mainUtils.extra.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850489a6884832da07d42d03747269a