### PR TITLE
Add tests for tab and container management

### DIFF
--- a/__tests__/useTabManagement.test.js
+++ b/__tests__/useTabManagement.test.js
@@ -26,10 +26,65 @@ describe('useTabManagement hook', () => {
     document.body.appendChild(container);
     const ref = { current: container };
     const terms = [{ id: 1 }, { id: 2 }];
-    const { result } = renderHook(() => useTabManagement(ref, terms, 2));
+    const { result, unmount } = renderHook(() => useTabManagement(ref, terms, 2));
     act(() => { jest.runAllTimers(); });
     expect(result.current.visibleTabs.map(t => t.id)).toEqual([2]);
     expect(result.current.overflowTabs.map(t => t.id)).toEqual([1]);
+    unmount();
+    document.body.removeChild(container);
+    jest.useRealTimers();
+  });
+
+  test('recalculateVisibleTabs when active tab already visible', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'clientWidth', { value: 90 });
+    const t1 = document.createElement('div');
+    t1.className = 'tab';
+    Object.defineProperty(t1, 'offsetWidth', { value: 50 });
+    const t2 = document.createElement('div');
+    t2.className = 'tab';
+    Object.defineProperty(t2, 'offsetWidth', { value: 50 });
+    container.appendChild(t1);
+    container.appendChild(t2);
+    const ref = { current: container };
+    const terms = [{ id: 1 }, { id: 2 }];
+    const { result, unmount } = renderHook(() => useTabManagement(ref, terms, 1));
+    act(() => { jest.runAllTimers(); });
+    expect(result.current.visibleTabs.map(t => t.id)).toEqual([1]);
+    expect(result.current.overflowTabs.map(t => t.id)).toEqual([2]);
+    unmount();
+    jest.useRealTimers();
+  });
+
+  test('toggleOverflowTabs stops event propagation', () => {
+    const ref = { current: document.createElement('div') };
+    const emptyTerms = [];
+    const { result, unmount } = renderHook(() => useTabManagement(ref, emptyTerms, null));
+    const e = { stopPropagation: jest.fn(), preventDefault: jest.fn() };
+    act(() => { result.current.toggleOverflowTabs(e); });
+    expect(e.stopPropagation).toHaveBeenCalled();
+    expect(e.preventDefault).toHaveBeenCalled();
+    unmount();
+  });
+
+  test('click outside closes overflow dropdown', () => {
+    jest.useFakeTimers();
+    const container = document.createElement('div');
+    const button = document.createElement('div');
+    button.className = 'overflow-indicator';
+    container.appendChild(button);
+    const ref = { current: container };
+    document.body.appendChild(container);
+    const emptyTerms = [];
+    const { result, unmount } = renderHook(() => useTabManagement(ref, emptyTerms, null));
+    act(() => { result.current.toggleOverflowTabs(); });
+    act(() => { jest.runAllTimers(); });
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    expect(result.current.overflowTabsOpen).toBe(false);
+    unmount();
     jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- extend `useTabManagement.test.js` with cleanup and stable props
- adjust failure expectations in `containerManagement.extra.test.js`

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:jest --silent`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:jest:coverage:text`


------
https://chatgpt.com/codex/tasks/task_e_68507cdf38a0832da351d9525d75bb98