### PR TITLE
Fix E2E success threshold check

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -480,6 +480,13 @@ jobs:
             
             ${{ env.E2E_NON_PASSING_DETAILS }}
             </details>
-            
+
             ---
-            *E2E tests validate the complete application workflow including UI interactions, terminal operations, and configuration management.* 
+            *E2E tests validate the complete application workflow including UI interactions, terminal operations, and configuration management.*
+      - name: Fail job if E2E success rate below threshold
+        if: always()
+        run: |
+          if [ "${{ env.E2E_SUCCESS_PERCENTAGE }}" -lt 85 ]; then
+            echo "E2E tests did not meet success threshold (${E2E_SUCCESS_PERCENTAGE}%)"
+            exit 1
+          fi

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -78,6 +78,13 @@ jobs:
             
             See the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for detailed coverage report and any failed tests.
             </details>
+      - name: Fail job if mock tests failed
+        if: always()
+        run: |
+          if [ "${{ env.MOCK_TESTS_FAILED }}" != "0" ]; then
+            echo "Jest mock tests failed"
+            exit 1
+          fi
 
   jest-prod:
     name: Jest Prod Coverage
@@ -146,4 +153,11 @@ jobs:
             <summary>View full results</summary>
             
             See the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for detailed coverage report and any failed tests.
-            </details> 
+            </details>
+      - name: Fail job if prod tests failed
+        if: always()
+        run: |
+          if [ "${{ env.PROD_TESTS_FAILED }}" != "0" ]; then
+            echo "Jest prod tests failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- tweak E2E workflow so it only fails when success rate drops below the threshold
- keep jest workflows failing when mock or prod tests fail
- ensure workflow YAML files end with a newline

## Testing
- `npm test` *(fails to run all E2E tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851b0b178c8832db0c0d87370b0c2cc