### PR TITLE
Add screenshot capture workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -325,6 +325,15 @@ jobs:
           echo "$NON_PASSING_DETAILS" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
+      - name: Capture UI screenshots
+        if: always()
+        run: |
+          npm run build
+          node scripts/capture-screenshots.js > screenshot_comment.md
+          echo "SCREENSHOT_COMMENT<<EOF" >> $GITHUB_ENV
+          cat screenshot_comment.md >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Post PR comment with E2E test summary
         uses: peter-evans/create-or-update-comment@v4
         with:
@@ -342,7 +351,7 @@ jobs:
             - ❌ Failed: ${{ env.E2E_TESTS_FAILED }}
             
             ${{ env.E2E_MESSAGE }}
-            
+
             <details>
             <summary>📋 View detailed results</summary>
             
@@ -356,6 +365,8 @@ jobs:
             
             ${{ env.E2E_NON_PASSING_DETAILS }}
             </details>
+
+            ${{ env.SCREENSHOT_COMMENT }}
 
             ---
             *E2E tests validate the complete application workflow including UI interactions, terminal operations, and configuration management.*

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ out/
 
 # Playwright reports
 /playwright-report/
-/test-results/
+/test-results/screenshots/
+screenshots/

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@testing-library/react": "^16.3.0",
         "babel-jest": "^29.7.0",
         "babel-loader": "^9.1.3",
+        "capture-electron": "^4.0.3",
         "css-loader": "^7.1.1",
         "entities": "^5.0.0",
         "html-webpack-plugin": "^5.6.0",
@@ -4212,6 +4213,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/capture-electron": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/capture-electron/-/capture-electron-4.0.3.tgz",
+      "integrity": "sha512-d11WgzjNajG+FZu5j7GpnrM+ix4Q8DhfWXzIR2ZdOCW5lAQdq7En1+RzuF5bK6I6YJES8qIng1oezKh8YCprhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "electron": "^15.1.2",
+        "safe-buffer": "^5.1.1",
+        "shell-escape": "^0.2.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -10272,6 +10285,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-escape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -10,29 +10,36 @@
     "start": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && npx @electron/rebuild -f -w node-pty && electron .",
     "build": "webpack --mode development",
     "watch": "webpack --mode development --watch",
-
     "test": "npm run test:jest && npm run test:e2e",
     "test:jest": "npm run test:jest:prod -- --silent --verbose=false --noStackTrace --passWithNoTests --reporters=default && npm run test:jest:mock -- --silent --verbose=false --noStackTrace --passWithNoTests --reporters=default",
     "test:jest:prod": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && jest --config=jest.config.js",
     "test:jest:mock": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && jest --config=jest.config.mock.js",
-
     "test:jest:prod:coverage": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && jest --config=jest.config.js --coverage --coverageDirectory=coverage/prod",
     "test:jest:mock:coverage": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && jest --config=jest.config.mock.js --coverage --coverageDirectory=coverage/mock",
-
     "coverage:prepare": "mkdir -p coverage/merged-raw && cp coverage/prod/coverage-final.json coverage/merged-raw/prod.json && cp coverage/mock/coverage-final.json coverage/merged-raw/mock.json",
-
     "test:jest:coverage:base": "npm run test:jest:prod:coverage && npm run test:jest:mock:coverage && npm run coverage:prepare && nyc merge coverage/merged-raw coverage/merged/coverage.json",
     "test:jest:coverage:text": "npm run test:jest:coverage:base && nyc report --reporter=text --report-dir=coverage/merged --temp-dir=coverage/merged",
     "test:jest:coverage:html": "npm run test:jest:coverage:base && nyc report --reporter=html-spa --report-dir=coverage/merged --temp-dir=coverage/merged && open coverage/merged/index.html",
-
     "test:e2e": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test --reporter=list",
-    "test:e2e:report": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test"
+    "test:e2e:report": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test",
+    "capture:screens": "node scripts/capture-screenshots.js"
   },
   "nyc": {
     "all": true,
-    "include": ["src/**/*.js", "src/**/*.jsx"],
-    "extension": [".js", ".jsx"],
-    "reporter": ["html-spa", "lcov", "text", "text-summary"]
+    "include": [
+      "src/**/*.js",
+      "src/**/*.jsx"
+    ],
+    "extension": [
+      ".js",
+      ".jsx"
+    ],
+    "reporter": [
+      "html-spa",
+      "lcov",
+      "text",
+      "text-summary"
+    ]
   },
   "author": "",
   "license": "ISC",
@@ -60,6 +67,7 @@
     "@testing-library/react": "^16.3.0",
     "babel-jest": "^29.7.0",
     "babel-loader": "^9.1.3",
+    "capture-electron": "^4.0.3",
     "css-loader": "^7.1.1",
     "entities": "^5.0.0",
     "html-webpack-plugin": "^5.6.0",

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const electron = require('electron');
+const renderScript = require.resolve('capture-electron/script/render.js');
+
+async function captureScreen(name, screenParam) {
+  const url = `file://${path.resolve(__dirname, '..', 'index.html')}?screen=${screenParam}`;
+  const result = spawnSync(
+    electron,
+    ['--no-sandbox', renderScript, url, '1200', '900', '1000', 'png'],
+    { encoding: 'buffer' }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr.toString());
+  }
+  const img = result.stdout;
+  const screenshotDir = path.resolve(__dirname, '..', 'screenshots');
+  if (!fs.existsSync(screenshotDir)) {
+    fs.mkdirSync(screenshotDir);
+  }
+  fs.writeFileSync(path.join(screenshotDir, `${name}.png`), img);
+  const base64 = img.toString('base64');
+  fs.writeFileSync(path.join(screenshotDir, `${name}.b64`), base64);
+  return base64;
+}
+
+(async () => {
+  const shots = [
+    ['main-app', 'main'],
+    ['health-report', 'health-report'],
+    ['floating-terminal', 'floating-terminal'],
+    ['stopping-status', 'stopping-status']
+  ];
+
+  const results = {};
+  for (const [name, param] of shots) {
+    try {
+      results[name] = await captureScreen(name, param);
+      console.log(`Captured ${name}`);
+    } catch (err) {
+      console.error(`Failed to capture ${name}:`, err.message);
+    }
+  }
+
+  // Output markdown for PR comment
+  const lines = ['## \uD83D\uDCF7 UI Screenshots'];
+  for (const [name] of shots) {
+    const data = results[name];
+    if (data) {
+      lines.push(`![${name}](data:image/png;base64,${data})`);
+    }
+  }
+  console.log(lines.join('\n'));
+})();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,6 +102,33 @@ const App = () => {
     floatingTerminalHandlers
   });
 
+  // Auto-open specific screens when a `screen` query param is provided
+  React.useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const screen = params.get('screen');
+    if (!screen) return;
+
+    switch (screen) {
+      case 'health-report':
+        appState.setIsHealthReportVisible(true);
+        break;
+      case 'floating-terminal':
+        floatingTerminalHandlers.openFloatingTerminal(
+          'screenshot',
+          'Screenshot Terminal',
+          'echo screenshot'
+        );
+        break;
+      case 'stopping-status':
+        if (appState.projectConfigRef.current?.showStoppingScreen) {
+          appState.projectConfigRef.current.showStoppingScreen();
+        }
+        break;
+      default:
+        break;
+    }
+  }, []);
+
   // Get live terminal data
   const [liveTerminals, setLiveTerminals] = React.useState([]);
   

--- a/src/components/ProjectConfiguration.jsx
+++ b/src/components/ProjectConfiguration.jsx
@@ -144,7 +144,8 @@ const ProjectConfiguration = forwardRef(({ projectName, globalDropdownValues, te
     setStateFromImport: ({ configState: newConfig, attachState: newAttach }) => {
       if (newConfig) setConfigState(newConfig);
       if (newAttach) setAttachState(newAttach);
-    }
+    },
+    showStoppingScreen: () => setShowStoppingScreen(true)
   }));
 
   return (


### PR DESCRIPTION
## Summary
- install `capture-electron`
- add screenshot capture script
- ignore generated screenshots
- open screens based on `screen` query param
- expose `showStoppingScreen` via config ref
- run screenshot capture in CI and include in PR comment

## Testing
- `npm test` *(fails: Unable to run e2e tests in container)*

------
https://chatgpt.com/codex/tasks/task_e_6851e1de9414832d94cdb14a655a7e33