### PR TITLE
Add Playwright visual regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,41 @@
+name: Visual Regression
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up NVM and Node.js
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+          . "$NVM_DIR/nvm.sh"
+          nvm install 22.16.0
+          nvm use 22.16.0
+      - name: Install dependencies
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          . "$NVM_DIR/nvm.sh"
+          nvm use 22.16.0
+          npm ci
+      - name: Rebuild native modules for Electron
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          . "$NVM_DIR/nvm.sh"
+          nvm use 22.16.0
+          npx @electron/rebuild -f -w node-pty
+      - name: Setup Mock Environment
+        run: bash scripts/setup-mock-e2e-env.sh
+      - name: Run Visual Regression Tests
+        run: |
+          export NVM_DIR="$HOME/.nvm"
+          . "$NVM_DIR/nvm.sh"
+          nvm use 22.16.0
+          npm run test:vr

--- a/__tests__/visual/app.visual.spec.js
+++ b/__tests__/visual/app.visual.spec.js
@@ -1,0 +1,112 @@
+const { test, expect } = require('@playwright/test');
+const { launchElectron, getTimeout } = require('../e2e/test-helpers');
+
+// Helper to ensure a verification section is expanded
+async function expandGeneralVerification(window) {
+  const envHeader = window.locator('.environment-verification-container .verification-header');
+  const toggle = envHeader.locator('.toggle-icon');
+  const isCollapsed = await toggle.evaluate(el => el.textContent.includes('▶'));
+  if (isCollapsed) {
+    await toggle.click();
+    await window.waitForTimeout(getTimeout(500));
+  }
+}
+
+test.describe('Visual Regression', () => {
+  let electronApp;
+  let window;
+
+  test.beforeEach(async () => {
+    const launchResult = await launchElectron();
+    electronApp = launchResult.electronApp;
+    window = launchResult.window;
+    await window.waitForSelector('.config-container', { timeout: getTimeout(20000) });
+  });
+
+  test.afterEach(async () => {
+    await electronApp.close();
+  });
+
+  test('main app', async () => {
+    expect(await window.screenshot()).toMatchSnapshot('main-app.png');
+  });
+
+  test('sidebar expanded', async () => {
+    const collapseButton = window.locator('.config-collapse-btn');
+    await collapseButton.click();
+    await window.waitForTimeout(getTimeout(500));
+    await collapseButton.click();
+    await window.waitForTimeout(getTimeout(500));
+    expect(await window.screenshot()).toMatchSnapshot('sidebar-expanded.png');
+  });
+
+  test('general verification expanded', async () => {
+    await expandGeneralVerification(window);
+    const container = window.locator('.environment-verification-container');
+    expect(await container.screenshot()).toMatchSnapshot('general-verification-expanded.png');
+  });
+
+  test('stopping status screen', async () => {
+    const mirrorSection = window.locator('h2:has-text("Mirror + MariaDB")').locator('..').locator('..');
+    const toggle = mirrorSection.locator('input[type="checkbox"]').first();
+    await toggle.click();
+    await window.waitForTimeout(500);
+    const attachToggle = mirrorSection.locator('#attach-mirror');
+    await attachToggle.click();
+    const runOptionSelector = `[data-testid="mode-selector-btn-mirror-run"]`;
+    await window.waitForSelector(runOptionSelector);
+    await window.click(runOptionSelector);
+
+    const runButton = window.locator('#run-configuration-button');
+    await runButton.click();
+    await expect(window.locator('.tab').first()).toBeVisible({ timeout: getTimeout(10000) });
+
+    await runButton.click();
+    const overlay = window.locator('.stopping-status-overlay');
+    await expect(overlay).toBeVisible({ timeout: getTimeout(5000) });
+    expect(await overlay.screenshot()).toMatchSnapshot('stopping-status-screen.png');
+
+    const closeBtn = overlay.locator('button.close-button');
+    await closeBtn.waitFor({ state: 'visible', timeout: getTimeout(30000) });
+    await closeBtn.click();
+    await expect(overlay).not.toBeVisible({ timeout: getTimeout(5000) });
+  });
+
+  test('health report screen', async () => {
+    const expandButton = window.locator('[title="Expand Sidebar"]');
+    await expandButton.click();
+    const healthReportButton = window.locator('[data-testid="health-report-button"]');
+    await healthReportButton.click();
+    await expect(window.locator('.health-report-container')).toBeVisible({ timeout: getTimeout(10000) });
+    expect(await window.screenshot()).toMatchSnapshot('health-report-screen.png');
+  });
+
+  test('floating terminal', async () => {
+    await expandGeneralVerification(window);
+    const fixButton = window.locator('.fix-button').first();
+    await fixButton.click();
+    const confirm = window.locator('.confirm-button');
+    await confirm.click();
+    const terminal = window.locator('.floating-terminal-window').first();
+    await expect(terminal).toBeVisible({ timeout: getTimeout(10000) });
+    expect(await terminal.screenshot()).toMatchSnapshot('floating-terminal.png');
+  });
+
+  test('tab info panel', async () => {
+    // ensure terminal from previous test exists
+    const infoButton = window.locator('.tab-info-button').first();
+    await infoButton.click();
+    const panel = window.locator('.tab-info-panel');
+    await expect(panel).toBeVisible({ timeout: getTimeout(10000) });
+    expect(await panel.screenshot()).toMatchSnapshot('tab-info.png');
+  });
+
+  test('tab info more details', async () => {
+    const panel = window.locator('.tab-info-panel');
+    const moreDetails = panel.locator('button', { hasText: 'More Details' });
+    await moreDetails.click();
+    const popup = window.locator('.command-popup');
+    await expect(popup).toBeVisible({ timeout: getTimeout(10000) });
+    expect(await popup.screenshot()).toMatchSnapshot('tab-info-more-details.png');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testPathIgnorePatterns: [
     "/node_modules/",
     "/__tests__/e2e/",
+    "/__tests__/visual/",
     "/__tests__/ConfigSection.test.jsx",
     "/__tests__/componentsRender.test.jsx"
   ],

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:jest:coverage:html": "npm run test:jest:coverage:base && nyc report --reporter=html-spa --report-dir=coverage/merged --temp-dir=coverage/merged && open coverage/merged/index.html",
 
     "test:e2e": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test --reporter=list",
-    "test:e2e:report": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test"
+    "test:e2e:report": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test",
+    "test:vr": "npm run build && unset PREFIX && source ~/.nvm/nvm.sh && nvm use && E2E_ENV=prod npx playwright test -c playwright.vrt.config.js"
   },
   "nyc": {
     "all": true,

--- a/playwright.vrt.config.js
+++ b/playwright.vrt.config.js
@@ -1,0 +1,8 @@
+const base = require('./playwright.config');
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+module.exports = {
+  ...base,
+  testDir: './__tests__/visual',
+  testMatch: /.*\.visual\.spec\.js/,
+};


### PR DESCRIPTION
## Summary
- add Playwright-based visual regression tests
- ignore visual tests from Jest
- expose `npm run test:vr` script
- new Playwright config for visual tests
- GitHub workflow to run the visual regression suite

## Testing
- `npm test`
- `npm run test:vr -- --update-snapshots` *(fails: Playwright tests did not pass)*

------
https://chatgpt.com/codex/tasks/task_e_6851eab47478832d938ca03db562c21b