### PR TITLE
Add screenshots for failed E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -143,6 +143,14 @@ jobs:
           name: e2e-logs
           path: e2e-output.txt
 
+      - name: Upload Playwright Screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-screenshots
+          path: test-results/**/*.png
+          if-no-files-found: ignore
+
       - name: Extract E2E Results
         if: always() # Always run to capture results even if tests fail
         run: |
@@ -267,6 +275,21 @@ jobs:
           else
             echo "E2E_TIMED_OUT_DETAILS=" >> $GITHUB_ENV
           fi
+
+      - name: Collect screenshots for comment
+        if: always()
+        run: |
+          SNIPPET=""
+          if [ -n "$(find test-results -name '*.png' -print -quit)" ]; then
+            for file in $(find test-results -name '*.png' | head -n 3); do
+              B64=$(base64 -w0 "$file")
+              NAME=$(basename "$file")
+              SNIPPET="${SNIPPET}\n\n![${NAME}](data:image/png;base64,${B64})"
+            done
+          fi
+          echo "E2E_SCREENSHOTS<<EOF" >> $GITHUB_ENV
+          echo "$SNIPPET" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
       - name: Determine test status
         if: always()
         run: |
@@ -353,8 +376,9 @@ jobs:
             - Mode: Headless
             - Timeout: 60 seconds per test
             - Mock environment with simulated tools and directories
-            
+
             ${{ env.E2E_NON_PASSING_DETAILS }}
+            ${{ env.E2E_SCREENSHOTS }}
             </details>
 
             ---

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -32,10 +32,13 @@ const config = {
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
     
     /* Run tests headlessly (invisible) */
     headless: true,
   },
+
+  outputDir: 'test-results',
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
## Summary
- collect Playwright screenshots on failure
- upload screenshots artifact
- embed screenshots in the PR comment for E2E runs
- capture screenshots via Playwright config

## Testing
- `npm test` *(fails: 2 failed e2e tests, 74 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_6851efa2f068832d86009d517d164c2e