### PR TITLE
Increase AppControlSidebar test coverage

### DIFF
--- a/__tests__/AppControlSidebar.debug.test.jsx
+++ b/__tests__/AppControlSidebar.debug.test.jsx
@@ -1,0 +1,61 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import AppControlSidebar from '../src/components/AppControlSidebar';
+
+beforeEach(() => {
+  global.ResizeObserver = class { observe(){} unobserve(){} disconnect(){} };
+});
+
+function getProps(overrides = {}) {
+  return {
+    floatingTerminals: [],
+    onShowTerminal: jest.fn(),
+    onCloseTerminal: jest.fn(),
+    onToggleMinimize: jest.fn(),
+    onOpenAbout: jest.fn(),
+    activeFloatingTerminalId: null,
+    isExpanded: false,
+    onToggleExpand: jest.fn(),
+    showTestSections: false,
+    noRunMode: false,
+    isProjectRunning: false,
+    onToggleTestSections: jest.fn(),
+    onToggleNoRunMode: jest.fn(),
+    showAppNotification: jest.fn(),
+    isMainTerminalWritable: false,
+    onToggleMainTerminalWritable: jest.fn(),
+    onExportConfig: jest.fn(),
+    onImportConfig: jest.fn(),
+    onToggleAllVerifications: jest.fn(),
+    onOpenHealthReport: jest.fn(),
+    healthStatus: 'green',
+    ...overrides
+  };
+}
+
+test('toggleDebugSection expands when collapsed', () => {
+  const props = getProps();
+  const { getByTitle } = render(<AppControlSidebar {...props} />);
+  fireEvent.click(getByTitle('Show Debug Tools'));
+  expect(props.onToggleExpand).toHaveBeenCalledWith(true);
+});
+
+test('openDevTools warns when electron missing', () => {
+  console.warn = jest.fn();
+  const props = getProps({ isExpanded: true });
+  const { getByText } = render(<AppControlSidebar {...props} />);
+  fireEvent.click(getByText('Debug'));
+  fireEvent.click(getByText('DevTools'));
+  expect(console.warn).toHaveBeenCalledWith('Electron API not available for openDevTools');
+});
+
+test('reloadApp falls back when electron missing', () => {
+  const reloadMock = jest.fn();
+  Object.defineProperty(window, 'location', { value: { ...window.location, reload: reloadMock }, writable: true });
+  const props = getProps({ isExpanded: true });
+  const { getByText } = render(<AppControlSidebar {...props} />);
+  fireEvent.click(getByText('Debug'));
+  fireEvent.click(getByText('⚠️ Reload (Risky)'));
+  expect(reloadMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add tests for AppControlSidebar debugging actions
- improve overall test coverage

## Testing
- `npm run lint`
- `npm run test:jest:coverage:text`

------
https://chatgpt.com/codex/tasks/task_e_68533de576f8832da3da960e33703178