### PR TITLE
Rename command sectionId field to id

### DIFF
--- a/__tests__/ConfigSection.test.jsx
+++ b/__tests__/ConfigSection.test.jsx
@@ -256,7 +256,7 @@ describe('ConfigSection', () => {
         };
 
         const mockCommands = [{
-            "sectionId": "testAnalyticsLogCommand",
+            "id": "testAnalyticsLogCommand",
             "command": {
                 "base": "tail -f /var/log/analytics.log",
                 "tabTitle": "Analytics Logs"
@@ -308,7 +308,7 @@ describe('ConfigSection', () => {
         };
 
         const mockCommands = [{
-            sectionId: 'childLogCommand',
+            id: 'childLogCommand',
             command: {
                 base: 'echo child log',
                 tabTitle: 'Child Logs'

--- a/__tests__/evalUtils.test.js
+++ b/__tests__/evalUtils.test.js
@@ -48,22 +48,22 @@ describe('generateCommandList', () => {
   ];
   const commands = [
     {
-      sectionId: 'sectionA',
+      id: 'sectionA',
       conditions: { enabled: true, 'attachState.sectionA': false },
       command: { base: 'cmdA', tabTitle: 'A' }
     },
     {
-      sectionId: 'sectionA',
+      id: 'sectionA',
       conditions: { enabled: true, 'attachState.sectionA': true },
       command: { base: 'cmdA-debug', tabTitle: 'A debug' }
     },
     {
-      sectionId: 'sectionB',
+      id: 'sectionB',
       conditions: { enabled: true, mode: 'dev' },
       command: { base: 'cmdB-dev', tabTitle: 'B dev' }
     },
     {
-      sectionId: 'sectionB',
+      id: 'sectionB',
       conditions: { enabled: true, deploymentType: 'container' },
       command: { base: 'cmdB-container', tabTitle: 'B container' }
     }
@@ -139,7 +139,7 @@ test('handles associated container conditions and strings', () => {
   const sections = [{ id: 'sec', title: 'Sec', components: {} }];
   const commands = [
     {
-      sectionId: 'sec',
+      id: 'sec',
       command: {
         base: 'run',
         tabTitle: 'T',
@@ -178,7 +178,7 @@ test('produces error for enabled sub-section when no matching command', () => {
   }];
   const commands = [
     {
-      sectionId: 'child-sub',
+      id: 'child-sub',
       conditions: { enabled: false },
       command: { base: 'cmd', tabTitle: 'child' }
     }
@@ -198,7 +198,7 @@ test('handles prefixes, final appends and conditional tab titles', () => {
   const sections = [{ id: 'sec', title: 'Sec', components: {} }];
   const commands = [
     {
-      sectionId: 'sec',
+      id: 'sec',
       conditions: { enabled: true },
       command: {
         base: 'run ${version} ${mode}',
@@ -233,7 +233,7 @@ test('generateCommandList resolves placeholders from multiple sources', () => {
   ];
   const commands = [
     {
-      sectionId: 'child-sub',
+      id: 'child-sub',
       command: { base: 'run ${var} ${mode} ${ver} ${g}', tabTitle: 'T' }
     }
   ];

--- a/__tests__/mock-data/mockConfigurationSidebarCommands.json
+++ b/__tests__/mock-data/mockConfigurationSidebarCommands.json
@@ -1,6 +1,6 @@
 [
   {
-    "sectionId": "generic-section-1",
+    "id": "generic-section-1",
     "conditions": {
       "enabled": true,
       "mode": "run"
@@ -11,7 +11,7 @@
     }
   },
   {
-    "sectionId": "generic-subsection-1",
+    "id": "generic-subsection-1",
     "conditions": {
       "generic-section-1Config.enabled": true,
       "generic-subsection-1Config.enabled": true,
@@ -23,7 +23,7 @@
     }
   },
   {
-    "sectionId": "generic-section-2",
+    "id": "generic-section-2",
     "conditions": {
       "enabled": true,
       "deploymentType": "container"
@@ -34,14 +34,14 @@
     }
   },
   {
-    "sectionId": "mock-button-command",
+    "id": "mock-button-command",
     "command": {
       "base": "echo 'Floating terminal for mock button'",
       "tabTitle": "Mock Button Logs"
     }
   },
   {
-    "sectionId": "test-section-generic",
+    "id": "test-section-generic",
     "conditions": {
       "enabled": true,
       "mode": "alpha"
@@ -52,7 +52,7 @@
     }
   },
   {
-    "sectionId": "testSubLogCommand",
+    "id": "testSubLogCommand",
     "command": {
       "base": "echo 'Sub section logs'",
       "tabTitle": "Sub Logs"

--- a/docs/command-system.md
+++ b/docs/command-system.md
@@ -21,7 +21,7 @@ Commands are defined in `src/configurationSidebarCommands.json`:
 ```json
 [
   {
-    "sectionId": "frontend",
+    "id": "frontend",
     "conditions": {
       "enabled": true
     },
@@ -65,7 +65,7 @@ Commands are defined in `src/configurationSidebarCommands.json`:
 
 ### Basic Properties
 
-- **`sectionId`** (string, required): ID that links this command definition. It can be:
+- **`id`** (string, required): ID that links this command definition. It can be:
     - The `id` of a top-level section defined in `src/configurationSidebarSections.json` (for commands run in main tabs).
     - The `id` of a sub-section defined within a top-level section in `src/configurationSidebarSections.json` (for commands run in main tabs).
     - The `commandId` of a `customButton` defined in `src/configurationSidebarSections.json` (for commands typically run in floating terminals).
@@ -101,7 +101,7 @@ Use separate command objects when handling multiple command variants. They:
 ```json
 [
   {
-    "sectionId": "your-analytics-section",
+    "id": "your-analytics-section",
     "conditions": {
       "enabled": true,
       "mode": "run"
@@ -114,7 +114,7 @@ Use separate command objects when handling multiple command variants. They:
     }
   },
   {
-    "sectionId": "your-analytics-section",
+    "id": "your-analytics-section",
     "conditions": {
       "enabled": true,
       "mode": "suspend"
@@ -133,7 +133,7 @@ Use separate command objects when handling multiple command variants. They:
 ```json
 [
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -148,7 +148,7 @@ Use separate command objects when handling multiple command variants. They:
     }
   },
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -163,7 +163,7 @@ Use separate command objects when handling multiple command variants. They:
     }
   },
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -283,12 +283,12 @@ Conditions are JavaScript expressions evaluated against the `configState` and `a
 
 ### Available Context for Conditions
 
-When defining conditions in `configurationSidebarCommands.json` for a command associated with a `sectionId`:
+When defining conditions in `configurationSidebarCommands.json` for a command entry with a given `id`:
 
-1.  **Direct Properties of the `sectionId`'s Config Object**:
-    *   If `sectionId` refers to a **top-level section** (e.g., `"alpha"`), simple keys like `"enabled"` or `"deploymentType"` refer to `configState.alpha.enabled` or `configState.alpha.deploymentType`.
-    *   If `sectionId` refers to a **sub-section** (e.g., `"frontend"`, which is a sub-section of `"alpha"`), simple keys like `"enabled"` or `"deploymentType"` refer to properties within that sub-section's specific config object (e.g., `configState.alpha.frontendConfig.enabled` or `configState.alpha.frontendConfig.deploymentType`).
-    *   **Dropdown Values for Sub-section Dropdowns**: If a dropdown is defined within a sub-section (e.g., `urlIntelPod` in `url-intelligence-sub` which is under `url-intelligence`), its value is stored directly on the parent section's config object (e.g., `configState['url-intelligence'].urlIntelPod`). Conditions for the sub-section command can reference this as `urlIntelPod` (if `sectionId` for the command is `url-intelligence-sub`, the variable resolver will check its parent `url-intelligence` for `urlIntelPod`). A boolean flag like `urlIntelPodSelected` is also available on the parent section's config: `configState['url-intelligence'].urlIntelPodSelected`.
+1.  **Direct Properties of the referenced section's config object**:
+    *   If the `id` refers to a **top-level section** (e.g., `"alpha"`), simple keys like `"enabled"` or `"deploymentType"` refer to `configState.alpha.enabled` or `configState.alpha.deploymentType`.
+    *   If the `id` refers to a **sub-section** (e.g., `"frontend"`, which is a sub-section of `"alpha"`), simple keys like `"enabled"` or `"deploymentType"` refer to properties within that sub-section's specific config object (e.g., `configState.alpha.frontendConfig.enabled` or `configState.alpha.frontendConfig.deploymentType`).
+    *   **Dropdown Values for Sub-section Dropdowns**: If a dropdown is defined within a sub-section (e.g., `urlIntelPod` in `url-intelligence-sub` which is under `url-intelligence`), its value is stored directly on the parent section's config object (e.g., `configState['url-intelligence'].urlIntelPod`). Conditions for the sub-section command can reference this as `urlIntelPod` (if the command `id` is `url-intelligence-sub`, the variable resolver will check its parent `url-intelligence` for `urlIntelPod`). A boolean flag like `urlIntelPodSelected` is also available on the parent section's config: `configState['url-intelligence'].urlIntelPodSelected`.
 
 2.  **Properties of Other Top-Level Section Configs (Cross-Section References)**:
     *   Use the format `"sectionNameConfig.propertyName"` (e.g., `"alphaConfig.enabled"`). This will correctly resolve to `configState.alpha.enabled`.
@@ -303,7 +303,7 @@ When defining conditions in `configurationSidebarCommands.json` for a command as
 
 ### Expression Examples
 
-**For a command with `"sectionId": "alpha"`:**
+**For a command with `"id": "alpha"`:**
 ```javascript
 // Checks configState.alpha.enabled
 "enabled": true
@@ -312,7 +312,7 @@ When defining conditions in `configurationSidebarCommands.json` for a command as
 "frontendConfig.deploymentType": "dev"
 ```
 
-**For a command with `"sectionId": "frontend"` (sub-section of `alpha`):**
+**For a command with `"id": "frontend"` (sub-section of `alpha`):**
 ```javascript
 // Checks configState.alpha.enabled (parent section enabled status)
 "alphaConfig.enabled": true
@@ -328,9 +328,9 @@ When defining conditions in `configurationSidebarCommands.json` for a command as
 "frontendConfig.deploymentType": "dev"
 ```
 
-**For a command with `"sectionId": "url-intelligence-sub"` (sub-section of `url-intelligence` with a dropdown `urlIntelPod`):**
+**For a command with `"id": "url-intelligence-sub"` (sub-section of `url-intelligence` with a dropdown `urlIntelPod`):**
 ```json
-// "sectionId": "url-intelligence-sub"
+// "id": "url-intelligence-sub"
 "conditions": {
   // Checks configState['url-intelligence'].urlIntelPodSelected (boolean flag for the dropdown)
   "urlIntelPodSelected": true
@@ -512,7 +512,7 @@ Define associated containers in your command configuration:
 
 ```json
 {
-  "sectionId": "backend",
+  "id": "backend",
   "conditions": {
     "enabled": true
   },
@@ -563,7 +563,7 @@ Container status is available in the Tab Information Panel:
 **Mixed Deployment Modes:**
 ```json
 {
-  "sectionId": "your-section-beta",
+  "id": "your-section-beta",
   "conditions": {
     "enabled": true,
     "deploymentType": "container"

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -277,7 +277,7 @@ To define a custom button, add a `customButton` object to the `components` array
 
 ### Linking to Commands:
 
-The `commandId` from your `customButton` configuration maps to an entry in `src/configurationSidebarCommands.json`. In this file, you need an object where the `sectionId` property matches your `customButton.commandId`.
+The `commandId` from your `customButton` configuration maps to an entry in `src/configurationSidebarCommands.json`. In this file, you need an object where the `id` property matches your `customButton.commandId`.
 
 This command object defines:
 -   `command.base` (string): The actual shell command to be executed in the floating terminal.
@@ -316,7 +316,7 @@ Let's say you want to add a button to the "alpha + MariaDB" section to quickly v
 [
   // ... other commands ...
   {
-    "sectionId": "alphaLogViewerCommand",
+    "id": "alphaLogViewerCommand",
     "command": {
       "base": "tail -f /var/log/alpha.log", // Example command
       "tabTitle": "alpha Logs"
@@ -378,14 +378,14 @@ Contains section descriptions and verification definitions.
 
 **File**: `src/configurationSidebarCommands.json`
 
-Defines command generation logic for each top-level section and also for individual sub-sections if they need to run their own commands in separate tabs. The `sectionId` in a command definition should match an `id` from `configurationSidebarSections.json` (for a top-level section) or a `subSection.id` (for a sub-section within a top-level section).
+Defines command generation logic for each top-level section and also for individual sub-sections if they need to run their own commands in separate tabs. The command `id` should match an `id` from `configurationSidebarSections.json` (for a top-level section) or a `subSection.id` (for a sub-section within a top-level section).
 
 Commands should be defined using separate command objects for each variant. This approach provides better reliability, maintainability, and clarity.
 
 ```json
 [
   {
-    "sectionId": "your-section",
+    "id": "your-section",
     "conditions": {
       "enabled": true,
       "deploymentType": "container"
@@ -397,7 +397,7 @@ Commands should be defined using separate command objects for each variant. This
     }
   },
   {
-    "sectionId": "your-section", 
+    "id": "your-section",
     "conditions": {
       "enabled": true,
       "deploymentType": "process"
@@ -412,7 +412,7 @@ Commands should be defined using separate command objects for each variant. This
 ```
 
 **Command Structure**:
-- `sectionId`: ID of the section or sub-section (must match an ID from `configurationSidebarSections.json`)
+- `id`: ID of the section or sub-section (must match an ID from `configurationSidebarSections.json`)
 - `conditions`: Object with condition properties that must all be true for the command to be generated
 - `command`: Command configuration object
 
@@ -497,7 +497,7 @@ To add a new section:
 2. **Add to `configurationSidebarAbout.json`**:
    ```json
    {
-     "sectionId": "my-new-section",
+     "id": "my-new-section",
      "directoryPath": "my-new-section",
      "description": "Description of my new section.",
      "verifications": []
@@ -514,10 +514,10 @@ To add a new section:
    ```
 
 3. **Add to `configurationSidebarCommands.json`**:
-   Define command logic. The `sectionId` here can be the ID of your new top-level section, or the ID of a sub-section if it needs its own command tab.
+   Define command logic. The `id` here can be the ID of your new top-level section, or the ID of a sub-section if it needs its own command tab.
    ```json
    {
-     "sectionId": "my-new-section",
+     "id": "my-new-section",
      "conditions": {
        "enabled": true
      },
@@ -566,7 +566,7 @@ This will:
 ## Best Practices
 
 ### Naming Conventions
-- Use kebab-case for `sectionId` in JSON files
+- Use kebab-case for `id` in JSON files
 - Use camelCase for state property names (automatically converted)
 - Use descriptive, unique IDs for verifications and commands
 
@@ -592,7 +592,7 @@ This will:
 
 ### Common Issues
 
-1. **Section not appearing**: Check that `sectionId` matches across all three configuration files
+1. **Section not appearing**: Check that the `id` matches across all three configuration files
 2. **Commands not generating**: Verify condition expressions and state property names
 3. **Verifications failing**: Test verification commands manually and check paths
 4. **UI components not working**: Ensure component definitions are valid JSON

--- a/docs/terminal-features.md
+++ b/docs/terminal-features.md
@@ -175,7 +175,7 @@ Add a `refreshConfig` object to any command definition in `configurationSidebarC
 
 ```json
 {
-  "sectionId": "alpha",
+  "id": "alpha",
   "conditions": {
     "enabled": true
   },

--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -314,7 +314,7 @@ const ConfigSection = ({
           {buttonsToRender.length > 0 && (
             <div className="custom-buttons-container">
               {buttonsToRender.map(button => {
-                const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                const commandDef = configSidebarCommands.find(c => c.id === button.commandId);
                 const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
                 
                 const isDisabled = isLocked || !config.enabled || (button.id === 'viewLogs' && isLogsDisabled());
@@ -396,7 +396,7 @@ const ConfigSection = ({
                         {subSection.components.customButtons && subSection.components.customButtons.length > 0 && (
                           <div className="custom-buttons-container">
                             {subSection.components.customButtons.map(button => {
-                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandDef = configSidebarCommands.find(c => c.id === button.commandId);
                               const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
                               const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
                               return (
@@ -421,7 +421,7 @@ const ConfigSection = ({
                           <div className="custom-buttons-container">
                             {(() => {
                               const button = subSection.components.customButton;
-                              const commandDef = configSidebarCommands.find(c => c.sectionId === button.commandId);
+                              const commandDef = configSidebarCommands.find(c => c.id === button.commandId);
                               const commandToRun = commandDef ? (commandDef.command.base || commandDef.command) : `echo "Command not found: ${button.commandId}"`;
                               const isDisabled = isLocked || !config.enabled || !subSectionConfig.enabled;
                               return (

--- a/src/configurationSidebarCommands.json
+++ b/src/configurationSidebarCommands.json
@@ -1,20 +1,20 @@
 [
   {
-    "sectionId": "testAnalyticsLogCommand",
+    "id": "testAnalyticsLogCommand",
     "command": {
       "base": "echo 'Floating terminal for Test Analytics Logs'",
       "tabTitle": "Test Analytics Logs"
     }
   },
   {
-    "sectionId": "mlEngineLogCommand",
+    "id": "mlEngineLogCommand",
     "command": {
       "base": "echo 'ML Engine logs'",
       "tabTitle": "ML Logs"
     }
   },
   {
-    "sectionId": "mirror",
+    "id": "mirror",
     "conditions": {
       "enabled": true,
       "attachState.mirror": false
@@ -34,7 +34,7 @@
     }
   },
   {
-    "sectionId": "mirror",
+    "id": "mirror",
     "conditions": {
       "enabled": true,
       "attachState.mirror": true,
@@ -55,7 +55,7 @@
     }
   },
   {
-    "sectionId": "mirror",
+    "id": "mirror",
     "conditions": {
       "enabled": true,
       "attachState.mirror": true,
@@ -76,7 +76,7 @@
     }
   },
   {
-    "sectionId": "frontend",
+    "id": "frontend",
     "conditions": {
       "mirrorConfig.enabled": true,
       "frontendConfig.enabled": true,
@@ -89,7 +89,7 @@
     }
   },
   {
-    "sectionId": "frontend",
+    "id": "frontend",
     "conditions": {
       "mirrorConfig.enabled": true,
       "frontendConfig.enabled": true,
@@ -102,7 +102,7 @@
     }
   },
   {
-    "sectionId": "gopm",
+    "id": "gopm",
     "conditions": {
       "enabled": true,
       "deploymentType": "process"
@@ -121,7 +121,7 @@
     }
   },
   {
-    "sectionId": "gopm",
+    "id": "gopm",
     "conditions": {
       "enabled": true,
       "deploymentType": "container"
@@ -134,7 +134,7 @@
     }
   },
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -149,7 +149,7 @@
     }
   },
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -164,7 +164,7 @@
     }
   },
   {
-    "sectionId": "url-intelligence-sub",
+    "id": "url-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -186,7 +186,7 @@
     }
   },
   {
-    "sectionId": "threat-intelligence-sub",
+    "id": "threat-intelligence-sub",
     "conditions": {
       "enabled": true,
       "url-intelligenceConfig.enabled": true,
@@ -201,7 +201,7 @@
     }
   },
   {
-    "sectionId": "activity-logger",
+    "id": "activity-logger",
     "conditions": {
       "enabled": true,
       "attachState.activity-logger": false
@@ -212,7 +212,7 @@
     }
   },
   {
-    "sectionId": "activity-logger",
+    "id": "activity-logger",
     "conditions": {
       "enabled": true,
       "attachState.activity-logger": true,
@@ -224,7 +224,7 @@
     }
   },
   {
-    "sectionId": "activity-logger",
+    "id": "activity-logger",
     "conditions": {
       "enabled": true,
       "attachState.activity-logger": true,
@@ -236,7 +236,7 @@
     }
   },
   {
-    "sectionId": "rule-engine",
+    "id": "rule-engine",
     "conditions": {
       "enabled": true,
       "deploymentType": "process"
@@ -256,7 +256,7 @@
     }
   },
   {
-    "sectionId": "rule-engine",
+    "id": "rule-engine",
     "conditions": {
       "enabled": true,
       "deploymentType": "container"
@@ -269,7 +269,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mode": "development"
@@ -282,7 +282,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mode": "staging"
@@ -295,7 +295,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mode": "production"
@@ -308,7 +308,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "dataProcessorConfig.enabled": true,
@@ -322,7 +322,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "dataProcessorConfig.enabled": true,
@@ -336,7 +336,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "dataProcessorConfig.enabled": true,
@@ -350,7 +350,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mlEngineConfig.enabled": true,
@@ -364,7 +364,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mlEngineConfig.enabled": true,
@@ -378,7 +378,7 @@
     }
   },
   {
-    "sectionId": "test-analytics",
+    "id": "test-analytics",
     "conditions": {
       "enabled": true,
       "mlEngineConfig.enabled": true,

--- a/src/utils/evalUtils.js
+++ b/src/utils/evalUtils.js
@@ -106,7 +106,7 @@ function generateCommandList(config, globalDropdowns, {
   const generatedCommandSectionIds = new Set();
 
   configSidebarCommands.forEach((commandDef, index) => {
-    const { sectionId: cmdSectionId, conditions, command } = commandDef;
+    const { id: cmdSectionId, conditions, command } = commandDef;
     const commandDefinitionId = index;
 
     const isDisplayableSectionOrSubSection = configSidebarSectionsActual.some(s =>
@@ -280,7 +280,7 @@ function generateCommandList(config, globalDropdowns, {
     const sectionId = sectionDef.id;
     const sectionTitle = sectionDef.title;
     if (config[sectionId]?.enabled) {
-      const hasCommandConfig = configSidebarCommands.some(cmd => cmd.sectionId === sectionId);
+      const hasCommandConfig = configSidebarCommands.some(cmd => cmd.id === sectionId);
       if (hasCommandConfig) {
         if (!generatedCommandSectionIds.has(sectionId)) {
           commands.push({
@@ -324,7 +324,7 @@ function generateCommandList(config, globalDropdowns, {
         const parentSectionId = sectionDef.id;
         const subSectionConfigKey = `${subSectionId.replace(/-sub$/, '')}Config`;
         if (config[parentSectionId]?.[subSectionConfigKey]?.enabled) {
-          const subHasCommandConfig = configSidebarCommands.some(cmd => cmd.sectionId === subSectionId);
+          const subHasCommandConfig = configSidebarCommands.some(cmd => cmd.id === subSectionId);
           if (subHasCommandConfig && !generatedCommandSectionIds.has(subSectionId)) {
             commands.push({
               title: subSectionTitle,


### PR DESCRIPTION
## Summary
- rename `sectionId` to `id` in `configurationSidebarCommands.json`
- update code to read the new field
- adjust tests and mock data
- document the new `id` property in docs

## Testing
- `npm run lint`
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_685340084c10832d9bbeb81718821720