### PR TITLE
Allow config json paths via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,21 @@ npm run build
 npm run watch
 ```
 
+### Using Mock Configuration
+
+You can bundle the app with the mock JSON files used in the test suite. This is
+handy for quick demonstrations or development without altering the real
+configuration:
+
+```bash
+npm run build:mock
+```
+
+The script sets the `CONFIG_SIDEBAR_SECTIONS`, `CONFIG_SIDEBAR_ABOUT`, and
+`CONFIG_SIDEBAR_COMMANDS` environment variables to the mock files under
+`__tests__/mock-data` before running the regular build. You can also set these
+variables manually to load custom configuration files.
+
 ### Native Module Rebuilding
 
 After installing new native dependencies:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "unset PREFIX && source ~/.nvm/nvm.sh && nvm use && npx @electron/rebuild -f -w node-pty && electron .",
     "build": "webpack --mode development",
+    "build:mock": "CONFIG_SIDEBAR_SECTIONS=/workspace/ProjectName-Manager/__tests__/mock-data/mockConfigurationSidebarSections.json CONFIG_SIDEBAR_ABOUT=/workspace/ProjectName-Manager/__tests__/mock-data/mockConfigurationSidebarAbout.json CONFIG_SIDEBAR_COMMANDS=/workspace/ProjectName-Manager/__tests__/mock-data/mockConfigurationSidebarCommands.json npm run build",
     "watch": "webpack --mode development --watch",
     "lint": "eslint --ext .js,.jsx .",
     "test": "npm run test:jest && npm run test:e2e",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -121,7 +121,9 @@ const App = () => {
   const autoSetup = useAutoSetup({
     verificationStatuses: appState.verificationStatuses,
     generalVerificationConfig: appState.generalVerificationConfig,
-    configSidebarAbout: require('./configurationSidebarAbout.json'),
+    configSidebarAbout: require(
+      process.env.CONFIG_SIDEBAR_ABOUT || './configurationSidebarAbout.json'
+    ),
     showTestSections: appState.showTestSections,
     onOpenFloatingTerminal: floatingTerminalHandlers.openFloatingTerminal,
     onCommandComplete: fixCommands.handleFixCommandComplete,

--- a/src/components/ConfigSection.jsx
+++ b/src/components/ConfigSection.jsx
@@ -8,7 +8,9 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import { STATUS } from '../constants/verificationConstants';
 import VerificationIndicator from './VerificationIndicator';
 import GitBranchSwitcher from './GitBranchSwitcher';
-import configSidebarAbout from '../configurationSidebarAbout.json';
+const configSidebarAbout = require(
+  process.env.CONFIG_SIDEBAR_ABOUT || '../configurationSidebarAbout.json'
+);
 import '../styles/config-section.css';
 
 const ConfigSection = ({ 

--- a/src/components/ProjectConfiguration.jsx
+++ b/src/components/ProjectConfiguration.jsx
@@ -3,8 +3,12 @@ import ConfigSection from './ConfigSection';
 import Notification from './Notification';
 import StoppingStatusScreen from './StoppingStatusScreen';
 import { STATUS } from '../constants/verificationConstants';
-import configSidebarSections from '../configurationSidebarSections.json';
-import configSidebarCommands from '../configurationSidebarCommands.json';
+const configSidebarSections = require(
+  process.env.CONFIG_SIDEBAR_SECTIONS || '../configurationSidebarSections.json'
+);
+const configSidebarCommands = require(
+  process.env.CONFIG_SIDEBAR_COMMANDS || '../configurationSidebarCommands.json'
+);
 import { generateCommandList } from '../utils/evalUtils';
 import { useProjectConfig } from '../hooks/useProjectConfig';
 import RunButton from './RunButton';

--- a/src/components/TerminalContainer.jsx
+++ b/src/components/TerminalContainer.jsx
@@ -5,7 +5,9 @@ import TabInfoPanel from './TabInfoPanel';
 import TerminalPlaceholder from './TerminalPlaceholder';
 import OverflowTabsDropdown from './OverflowTabsDropdown';
 import '@xterm/xterm/css/xterm.css';
-import configSidebarCommands from '../configurationSidebarCommands.json';
+const configSidebarCommands = require(
+  process.env.CONFIG_SIDEBAR_COMMANDS || '../configurationSidebarCommands.json'
+);
 import { useTerminals } from '../hooks/useTerminals';
 import { useTabManagement } from '../hooks/useTabManagement';
 import { useIpcListeners } from '../hooks/useIpcListeners';

--- a/src/hooks/useAppState.js
+++ b/src/hooks/useAppState.js
@@ -1,6 +1,8 @@
 import { useState, useRef } from 'react';
 import { STATUS } from '../constants/verificationConstants';
-import appConfig from '../configurationSidebarSections.json';
+const appConfig = require(
+  process.env.CONFIG_SIDEBAR_SECTIONS || '../configurationSidebarSections.json'
+);
 
 const { displaySettings, sections: configSidebarSections } = appConfig;
 

--- a/src/hooks/useFixCommands.js
+++ b/src/hooks/useFixCommands.js
@@ -1,7 +1,11 @@
 import { useCallback, useEffect } from 'react';
 import { STATUS } from '../constants/verificationConstants';
-import configurationSidebarAbout from '../configurationSidebarAbout.json';
-import configurationSidebarSections from '../configurationSidebarSections.json';
+const configurationSidebarAbout = require(
+  process.env.CONFIG_SIDEBAR_ABOUT || '../configurationSidebarAbout.json'
+);
+const configurationSidebarSections = require(
+  process.env.CONFIG_SIDEBAR_SECTIONS || '../configurationSidebarSections.json'
+);
 
 export const useFixCommands = ({
   appState,

--- a/src/hooks/useProjectConfig.js
+++ b/src/hooks/useProjectConfig.js
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { projectSelectorFallbacks } from '../constants/selectors';
-import configSidebarSections from '../configurationSidebarSections.json';
+const configSidebarSections = require(
+  process.env.CONFIG_SIDEBAR_SECTIONS || '../configurationSidebarSections.json'
+);
 
 const configSidebarSectionsActual = configSidebarSections.sections;
 

--- a/src/main/configurationManagement.js
+++ b/src/main/configurationManagement.js
@@ -5,8 +5,10 @@ const { exportConfigToFile, importConfigFromFile } = require('../../configIO');
 const { debugLog } = require('../utils/debugUtils');
 
 // Path to configuration files
-const CONFIG_SIDEBAR_ABOUT_PATH = path.join(__dirname, '../configurationSidebarAbout.json');
-const CONFIG_SIDEBAR_SECTIONS_PATH = path.join(__dirname, '../configurationSidebarSections.json');
+const CONFIG_SIDEBAR_ABOUT_PATH = process.env.CONFIG_SIDEBAR_ABOUT ||
+  path.join(__dirname, '../configurationSidebarAbout.json');
+const CONFIG_SIDEBAR_SECTIONS_PATH = process.env.CONFIG_SIDEBAR_SECTIONS ||
+  path.join(__dirname, '../configurationSidebarSections.json');
 
 // Function to load display settings
 async function loadDisplaySettings() {

--- a/src/main/dropdownManagement.js
+++ b/src/main/dropdownManagement.js
@@ -97,7 +97,8 @@ async function getDropdownOptions(config) {
 async function precacheGlobalDropdowns() {
     debugLog('Starting global dropdown pre-caching...');
     try {
-        const configPath = path.join(__dirname, '..', 'generalEnvironmentVerifications.json');
+        const configPath = process.env.GENERAL_VERIFICATIONS ||
+          path.join(__dirname, '..', 'generalEnvironmentVerifications.json');
         const configData = await fs.readFile(configPath, 'utf-8');
         const config = JSON.parse(configData);
 
@@ -199,7 +200,8 @@ async function executeDropdownChangeCommand(dropdownId, value, globalDropdownVal
 async function getDropdownConfig(dropdownId) {
   try {
     // Check generalEnvironmentVerifications.json first
-    const generalConfigPath = path.join(__dirname, '..', 'generalEnvironmentVerifications.json');
+    const generalConfigPath = process.env.GENERAL_VERIFICATIONS ||
+      path.join(__dirname, '..', 'generalEnvironmentVerifications.json');
     const generalConfigData = await fs.readFile(generalConfigPath, 'utf-8');
     const generalConfig = JSON.parse(generalConfigData);
     
@@ -209,7 +211,8 @@ async function getDropdownConfig(dropdownId) {
     }
 
     // Check configurationSidebarAbout.json for section-specific dropdowns
-    const aboutConfigPath = path.join(__dirname, '..', 'configurationSidebarAbout.json');
+    const aboutConfigPath = process.env.CONFIG_SIDEBAR_ABOUT ||
+      path.join(__dirname, '..', 'configurationSidebarAbout.json');
     const aboutConfigData = await fs.readFile(aboutConfigPath, 'utf-8');
     const aboutConfig = JSON.parse(aboutConfigData);
     

--- a/src/main/environmentVerification.js
+++ b/src/main/environmentVerification.js
@@ -20,8 +20,10 @@ let isVerifyingEnvironment = false; // Global flag for the whole process
 const projectRoot = path.resolve(__dirname, '../../..'); // Adjusted for new location
 
 // Path to the verifications configuration file
-const VERIFICATIONS_CONFIG_PATH = path.join(__dirname, '../generalEnvironmentVerifications.json');
-const CONFIG_SIDEBAR_ABOUT_PATH = path.join(__dirname, '../configurationSidebarAbout.json');
+const VERIFICATIONS_CONFIG_PATH = process.env.GENERAL_VERIFICATIONS ||
+  path.join(__dirname, '../generalEnvironmentVerifications.json');
+const CONFIG_SIDEBAR_ABOUT_PATH = process.env.CONFIG_SIDEBAR_ABOUT ||
+  path.join(__dirname, '../configurationSidebarAbout.json');
 
 const execCommand = async (commandString) => {
   debugLog(`Executing command: ${commandString}`);

--- a/src/main/gitManagement.js
+++ b/src/main/gitManagement.js
@@ -8,7 +8,8 @@ const projectRoot = path.resolve(__dirname, '../../..'); // Adjusted for new loc
 // Helper function to get Git branch with caching
 const gitBranchCache = {};
 
-const CONFIG_SIDEBAR_ABOUT_PATH = path.join(__dirname, '../configurationSidebarAbout.json');
+const CONFIG_SIDEBAR_ABOUT_PATH = process.env.CONFIG_SIDEBAR_ABOUT ||
+  path.join(__dirname, '../configurationSidebarAbout.json');
 
 const getGitBranch = async (relativePath) => {
   // Check cache first

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
@@ -54,6 +55,26 @@ module.exports = {
       }
     ],
   },
+  plugins: [
+    ...(process.env.CONFIG_SIDEBAR_SECTIONS ? [
+      new webpack.NormalModuleReplacementPlugin(
+        /configurationSidebarSections\.json$/,
+        path.resolve(__dirname, process.env.CONFIG_SIDEBAR_SECTIONS)
+      )
+    ] : []),
+    ...(process.env.CONFIG_SIDEBAR_ABOUT ? [
+      new webpack.NormalModuleReplacementPlugin(
+        /configurationSidebarAbout\.json$/,
+        path.resolve(__dirname, process.env.CONFIG_SIDEBAR_ABOUT)
+      )
+    ] : []),
+    ...(process.env.CONFIG_SIDEBAR_COMMANDS ? [
+      new webpack.NormalModuleReplacementPlugin(
+        /configurationSidebarCommands\.json$/,
+        path.resolve(__dirname, process.env.CONFIG_SIDEBAR_COMMANDS)
+      )
+    ] : [])
+  ],
   resolve: {
     extensions: ['.js', '.jsx']
   },


### PR DESCRIPTION
## Summary
- support reading json config paths from environment variables
- bundle mock config when `npm run build:mock` is used
- document how to build with mock configuration

## Testing
- `npm run lint`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_68539de048b0832d91d7a7eadd481f3c