### PR TITLE
Add validation tests for useProjectConfig

### DIFF
--- a/__tests__/mock-data/mockConfigValidation.json
+++ b/__tests__/mock-data/mockConfigValidation.json
@@ -1,0 +1,17 @@
+{
+  "sections": [
+    {
+      "id": "validation-section",
+      "title": "Validation Section",
+      "components": {
+        "toggle": true,
+        "mainToggle": {
+          "validationRequired": {
+            "condition": "gcloudProject && !projectSelectorFallbacks.includes(gcloudProject)",
+            "errorMessage": "Select a project first"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/__tests__/project-config/useProjectConfig.validation.test.js
+++ b/__tests__/project-config/useProjectConfig.validation.test.js
@@ -1,0 +1,34 @@
+jest.mock('../../src/project-config/config/configurationSidebarSections.json', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const file = fs.readFileSync(path.join(__dirname, '../mock-data/mockConfigValidation.json'), 'utf-8');
+  return JSON.parse(file);
+});
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useProjectConfig } from '../../src/project-config/hooks/useProjectConfig';
+
+describe('useProjectConfig validation', () => {
+  test('does not enable section when validation fails', async () => {
+    const notify = jest.fn();
+    const { result } = renderHook(() => useProjectConfig({}, false, notify));
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      result.current.toggleSectionEnabled('validation-section', true);
+    });
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(result.current.configState['validation-section'].enabled).toBe(false);
+  });
+
+  test('enables section when validation passes', async () => {
+    const notify = jest.fn();
+    const globals = { gcloudProject: 'my-project' };
+    const { result } = renderHook(() => useProjectConfig(globals, false, notify));
+    await waitFor(() => result.current.initialized);
+    act(() => {
+      result.current.toggleSectionEnabled('validation-section', true);
+    });
+    expect(notify).not.toHaveBeenCalled();
+    expect(result.current.configState['validation-section'].enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add mock config with validation requirement
- test validation behavior of `useProjectConfig`

## Testing
- `npm run lint`
- `npm run test:jest -- -t useProjectConfig.validation`

------
https://chatgpt.com/codex/tasks/task_e_6855b12fdbbc832d98d88a4398e162be