### PR TITLE
Improve RunButton component tests

### DIFF
--- a/__tests__/project-config/RunButton.test.jsx
+++ b/__tests__/project-config/RunButton.test.jsx
@@ -6,22 +6,38 @@ import RunButton from '../../src/project-config/RunButton';
 /** @jest-environment jsdom */
 
 describe('RunButton component', () => {
-  test('renders RUN state and handles click', () => {
+  test('shows RUN state with icon and triggers click handler', () => {
     const onClick = jest.fn();
     render(<RunButton projectName="demo" onClick={onClick} />);
-    const btn = screen.getByRole('button');
-    expect(btn).toHaveTextContent('RUN DEMO');
+    const btn = screen.getByRole('button', { name: /run demo/i });
+    expect(btn).toHaveClass('run-configuration-button');
+    expect(btn).not.toBeDisabled();
+    expect(btn.querySelector('.run-icon')).toBeInTheDocument();
+
     fireEvent.click(btn);
     expect(onClick).toHaveBeenCalled();
   });
 
-  test('renders STOP state', () => {
+  test('renders STOP state with proper class and icon', () => {
     render(<RunButton projectName="x" isRunning />);
-    expect(screen.getByRole('button')).toHaveTextContent('STOP X');
+    const btn = screen.getByRole('button', { name: /stop x/i });
+    expect(btn).toHaveClass('stop');
+    expect(btn.querySelector('.stop-icon')).toBeInTheDocument();
   });
 
-  test('renders STOPPING state', () => {
+  test('renders STOPPING state with proper class and icon', () => {
     render(<RunButton projectName="y" isStopping />);
-    expect(screen.getByRole('button')).toHaveTextContent('STOPPING Y');
+    const btn = screen.getByRole('button', { name: /stopping y/i });
+    expect(btn).toHaveClass('stopping');
+    expect(btn.querySelector('.stopping-icon')).toBeInTheDocument();
+  });
+
+  test('disables the button when disabled prop is true', () => {
+    const onClick = jest.fn();
+    render(<RunButton projectName="z" disabled onClick={onClick} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expand RunButton tests to check icons, classes and disabled state

## Testing
- `npm run lint`
- `npm run test:jest`

------
https://chatgpt.com/codex/tasks/task_e_6855b166026c832d90eb033868208c94