### PR TITLE
Fix auto setup group collapse

### DIFF
--- a/src/auto-setup/AutoSetupScreen.jsx
+++ b/src/auto-setup/AutoSetupScreen.jsx
@@ -50,18 +50,13 @@ const AutoSetupScreen = ({
         // Auto-expand logic:
         // - Running groups should always be expanded
         // - If no groups are running, expand the first waiting group
-        // - Collapse completed/failed groups unless manually expanded
+        // - Collapse completed/failed groups when they finish
         if (groupStatus === SECTION_STATUS.RUNNING) {
           newExpandedState[group.priority] = true;
           hasRunningGroup = true;
         } else if (groupStatus === SECTION_STATUS.SUCCESS || groupStatus === SECTION_STATUS.FAILED) {
-          // Collapse finished groups unless user manually expanded them
-          if (expandedGroups[group.priority] === undefined) {
-            newExpandedState[group.priority] = false;
-          } else {
-            // Keep user's manual preference for finished groups
-            newExpandedState[group.priority] = expandedGroups[group.priority];
-          }
+          // Always collapse finished groups
+          newExpandedState[group.priority] = false;
         } else if (groupStatus === SECTION_STATUS.WAITING) {
           // If no running group and this is the first waiting group, expand it
           if (!hasRunningGroup && index === 0) {


### PR DESCRIPTION
## Summary
- close finished auto setup groups so that the next running group expands and previous collapses automatically

## Testing
- `npm run test:jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685686d17a68832d8ab2b05dac8401d4