### PR TITLE
Fix Jest workflow overriding ESLint comments

### DIFF
--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -182,27 +182,56 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- GITHUB_ACTION_TEST_SUMMARY:${{ github.event.pull_request.head.sha }} -->'
       
+      - name: Prepare Comment Body
+        id: comment-body
+        run: |
+          if [ -z "${{ steps.fc.outputs.comment-id }}" ]; then
+            cat >> $GITHUB_OUTPUT << 'EOF'
+          body<<BODY_DELIMITER
+          <!-- GITHUB_ACTION_TEST_SUMMARY:${{ github.event.pull_request.head.sha }} -->
+          
+          ## 🔎 Test Summary
+          
+          ---
+          ### Jest Mock Coverage
+          - ✅ Passed: ${{ steps.parse-results.outputs.mock-passed }}
+          - ❌ Failed: ${{ steps.parse-results.outputs.mock-failed }}
+          - ⏭️ Skipped: ${{ steps.parse-results.outputs.mock-skipped }}
+          - 📈 Coverage: ${{ steps.parse-results.outputs.mock-coverage }}%
+          
+          ---
+          ### Jest Prod Coverage
+          - ✅ Passed: ${{ steps.parse-results.outputs.prod-passed }}
+          - ❌ Failed: ${{ steps.parse-results.outputs.prod-failed }}
+          - ⏭️ Skipped: ${{ steps.parse-results.outputs.prod-skipped }}
+          - 📈 Coverage: ${{ steps.parse-results.outputs.prod-coverage }}%
+          BODY_DELIMITER
+          EOF
+          else
+            cat >> $GITHUB_OUTPUT << 'EOF'
+          body<<BODY_DELIMITER
+          
+          ---
+          ### Jest Mock Coverage
+          - ✅ Passed: ${{ steps.parse-results.outputs.mock-passed }}
+          - ❌ Failed: ${{ steps.parse-results.outputs.mock-failed }}
+          - ⏭️ Skipped: ${{ steps.parse-results.outputs.mock-skipped }}
+          - 📈 Coverage: ${{ steps.parse-results.outputs.mock-coverage }}%
+          
+          ---
+          ### Jest Prod Coverage
+          - ✅ Passed: ${{ steps.parse-results.outputs.prod-passed }}
+          - ❌ Failed: ${{ steps.parse-results.outputs.prod-failed }}
+          - ⏭️ Skipped: ${{ steps.parse-results.outputs.prod-skipped }}
+          - 📈 Coverage: ${{ steps.parse-results.outputs.prod-coverage }}%
+          BODY_DELIMITER
+          EOF
+          fi
+      
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace  # Replace entire comment to ensure consistency
-          body: |
-            <!-- GITHUB_ACTION_TEST_SUMMARY:${{ github.event.pull_request.head.sha }} -->
-            
-            ## 🔎 Test Summary
-            
-            ---
-            ### Jest Mock Coverage
-            - ✅ Passed: ${{ steps.parse-results.outputs.mock-passed }}
-            - ❌ Failed: ${{ steps.parse-results.outputs.mock-failed }}
-            - ⏭️ Skipped: ${{ steps.parse-results.outputs.mock-skipped }}
-            - 📈 Coverage: ${{ steps.parse-results.outputs.mock-coverage }}%
-            
-            ---
-            ### Jest Prod Coverage
-            - ✅ Passed: ${{ steps.parse-results.outputs.prod-passed }}
-            - ❌ Failed: ${{ steps.parse-results.outputs.prod-failed }}
-            - ⏭️ Skipped: ${{ steps.parse-results.outputs.prod-skipped }}
-            - 📈 Coverage: ${{ steps.parse-results.outputs.prod-coverage }}%
+          edit-mode: append
+          body: ${{ steps.comment-body.outputs.body }}


### PR DESCRIPTION
- Change Jest workflow edit-mode from 'replace' to 'append'
- Add conditional comment body preparation similar to ESLint workflow
- Jest now appends to existing ESLint comments instead of replacing them
- Maintains consistent Test Summary format across both workflows