### PR TITLE
Fix: Resolve TBD mode notification not showing

### DIFF
--- a/src/common/hooks/useAppEventHandlers.js
+++ b/src/common/hooks/useAppEventHandlers.js
@@ -108,7 +108,7 @@ export const useAppEventHandlers = ({
     handleToggleNoRunMode,
     handleConfigStateChange,
     handleProjectRunStateChange,
-    handleShowAppNotification,
+    showAppNotification: handleShowAppNotification,
     hideAppNotification,
     handleRefresh,
     toggleMainTerminalWritable,


### PR DESCRIPTION
- Fixed missing showAppNotification prop in ModeSelector component
- Changed useAppEventHandlers return to expose showAppNotification correctly
- TBD mode clicks now properly display 'This feature is not yet implemented' notification
- Resolves issue where showAppNotification was undefined in component chain