### PR TITLE
Update version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 > The application has been tested on **macOS**. It should also work on **Linux**, though this has not been verified. Windows compatibility is not planned at this time.
 
-[![Electron](https://img.shields.io/badge/Electron-30.0.1-47848F?style=flat&logo=electron&logoColor=white)](https://electronjs.org/)
-[![React](https://img.shields.io/badge/React-18.2.0-61DAFB?style=flat&logo=react&logoColor=black)](https://reactjs.org/)
+[![Electron](https://img.shields.io/badge/Electron-36.5.0-47848F?style=flat&logo=electron&logoColor=white)](https://electronjs.org/)
+[![React](https://img.shields.io/badge/React-19.1.0-61DAFB?style=flat&logo=react&logoColor=black)](https://reactjs.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-22.16.0-339933?style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-lightgrey)](https://github.com/electron/electron)
 

--- a/__tests__/main-process/processCleanup.test.js
+++ b/__tests__/main-process/processCleanup.test.js
@@ -41,7 +41,7 @@ describe('Process cleanup', () => {
     proc.send('closeTab');
 
     await new Promise((resolve) => proc.once('message', resolve));
-    await wait(250); // Increased wait time to allow for cleanup
+    await wait(500); // Increased wait time to allow for cleanup on slow systems
 
     expect(isProcessRunning(childPid)).toBe(false);
     proc.kill();
@@ -68,7 +68,7 @@ describe('Process cleanup', () => {
 
     proc.kill('SIGTERM');
     await new Promise((resolve) => proc.once('exit', resolve));
-    await wait(200); // Increased wait time to allow for cleanup
+    await wait(500); // Increased wait time to allow for cleanup on slow systems
 
     expect(isProcessRunning(childPid)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- bump README badges for React and Electron
- increase wait time in processCleanup test to reduce flakes

## Testing
- `npm run test:jest`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858547f42b8832da17b2f531b974dcd