### PR TITLE
Remove duplicate doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ For complete documentation, see the **[Documentation Guides](docs/README.md)**.
 
 ### 🚀 Quick Start Guides
 - [Getting Started & Installation](docs/getting-started.md) - Detailed setup instructions
-- [Configuration Overview](docs/configuration/overview.md) - JSON configuration system basics
-- [Auto Setup Guide](docs/features/auto-setup.md) - Automated environment setup
 
 ### 🏗️ Architecture & Development
 - [Architecture Overview](docs/architecture/overview.md) - System design and components


### PR DESCRIPTION
## Summary
- remove duplicated documentation links in README

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:jest`


------
https://chatgpt.com/codex/tasks/task_e_685b0de4b14c832d95c87d638768f30d